### PR TITLE
flush also output buffer (TCIOFLUSH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Resumes a paused connection.
 
 ### .flush (callback)
 
-Flushes data received but not read. See [`tcflush()`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
+Flushes data received but not read and flushes data written but not transmitted. See [`tcflush()`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
 
 **_callback (optional)_**
 

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -350,7 +350,7 @@ int setup(int fd, OpenBaton *data) {
 
   // removed this unneeded sleep.
   // sleep(1);
-  tcflush(fd, TCIFLUSH);
+  tcflush(fd, TCIOFLUSH);
   tcsetattr(fd, TCSANOW, &options);
 
   // On OS X, starting in Tiger, we can set a custom baud rate, as follows:
@@ -727,7 +727,7 @@ void EIO_List(uv_work_t* req) {
 void EIO_Flush(uv_work_t* req) {
   FlushBaton* data = static_cast<FlushBaton*>(req->data);
 
-  data->result = tcflush(data->fd, TCIFLUSH);
+  data->result = tcflush(data->fd, TCIOFLUSH);
 }
 
 void EIO_Set(uv_work_t* req) {


### PR DESCRIPTION
use TCIOFLUSH instead of TCIFLUSH on linux build
```
TCIFLUSH
flushes data received but not read.
TCIOFLUSH
flushes both data received but not read, and data written but not transmitted.
```