### PR TITLE
remove references to bytesWritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ var SerialPort = require('serialport').SerialPort;
 var port = new SerialPort('/dev/tty-usbserial1');
 
 port.on('open', function () {
-  port.write('main screen turn on', function(err, bytesWritten) {
+  port.write('main screen turn on', function(err) {
     if (err) {
       return console.log('Error: ', err.message);
     }
-    console.log(bytesWritten, 'bytes written');
+    console.log('message written');
   });
 });
 ```
@@ -198,11 +198,11 @@ This could be moved to the constructor's callback.
 ```js
 var SerialPort = require('serialport').SerialPort;
 var port = new SerialPort('/dev/tty-usbserial1', function () {
-  port.write('main screen turn on', function(err, bytesWritten) {
+  port.write('main screen turn on', function(err) {
     if (err) {
       return console.log('Error: ', err.message);
     }
-    console.log(bytesWritten, 'bytes written');
+    console.log('message written');
   });
 });
 ```

--- a/examples/opening.js
+++ b/examples/opening.js
@@ -6,11 +6,11 @@
 // var port = new SerialPort('/dev/tty-usbserial1');
 
 // port.on('open', function () {
-//   port.write('main screen turn on', function(err, bytesWritten) {
+//   port.write('main screen turn on', function(err) {
 //     if (err) {
 //       return console.log('Error: ', err.message);
 //     }
-//     console.log(bytesWritten, 'bytes written');
+//     console.log('message written');
 //   });
 // });
 
@@ -20,11 +20,11 @@
 
 // var SerialPort = require('serialport').SerialPort;
 // var port = new SerialPort('/dev/tty-usbserial1', function () {
-//   port.write('main screen turn on', function(err, bytesWritten) {
+//   port.write('main screen turn on', function(err) {
 //     if (err) {
 //       return console.log('Error: ', err.message);
 //     }
-//     console.log(bytesWritten, 'bytes written');
+//     console.log('message written');
 //   });
 // });
 


### PR DESCRIPTION
The write completion callback no longer has a `bytesWritten` parameter. This PR removes the last three mentions of that parameter.