### PR TITLE
Add GetCommState to fix Error 87 on a Virtual Comm Port

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -81,8 +81,8 @@ void EIO_Open(uv_work_t* req) {
   dcb.DCBlength = sizeof(DCB);
   
   if (!GetCommState(file, &dcb)) {
-	printf("error getting comm state");
-	return;
+    ErrorCodeToString("GetCommState", GetLastError(), data->errorString);
+    return;
   }
   
   if (data->hupcl == false) {

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -77,7 +77,14 @@ void EIO_Open(uv_work_t* req) {
   }
 
   DCB dcb = { 0 };
+  SecureZeroMemory(&dcb, sizeof(DCB));
   dcb.DCBlength = sizeof(DCB);
+  
+  if (!GetCommState(file, &dcb)) {
+	printf("error getting comm state");
+	return;
+  }
+  
   if (data->hupcl == false) {
     dcb.fDtrControl = DTR_CONTROL_DISABLE;  // disable DTR to avoid reset
   } else {


### PR DESCRIPTION
I was getting Error Code 87 in SetCommState when using node-serialport on a Windows 10 laptop with a Virtual Comm Port but other Windows code I had would use the serial port correctly.

On checking the C++ code I noticed you were not reading the current DCB data structure from the serial port. This is a requirement of the Windows API and is shown in the example (taken from MSDN) below

I added the GetCommState and this fixed my problem.

Roger


Sample code from MSDN
```
#include <windows.h>
#include <tchar.h>
#include <stdio.h>

void PrintCommState(DCB dcb)
{
    //  Print some of the DCB structure values
    _tprintf( TEXT("\nBaudRate = %d, ByteSize = %d, Parity = %d, StopBits = %d\n"), 
              dcb.BaudRate, 
              dcb.ByteSize, 
              dcb.Parity,
              dcb.StopBits );
}


int _tmain( int argc, TCHAR *argv[] )
{
   DCB dcb;
   HANDLE hCom;
   BOOL fSuccess;
   TCHAR *pcCommPort = TEXT("COM1"); //  Most systems have a COM1 port

   //  Open a handle to the specified com port.
   hCom = CreateFile( pcCommPort,
                      GENERIC_READ | GENERIC_WRITE,
                      0,      //  must be opened with exclusive-access
                      NULL,   //  default security attributes
                      OPEN_EXISTING, //  must use OPEN_EXISTING
                      0,      //  not overlapped I/O
                      NULL ); //  hTemplate must be NULL for comm devices

   if (hCom == INVALID_HANDLE_VALUE) 
   {
       //  Handle the error.
       printf ("CreateFile failed with error %d.\n", GetLastError());
       return (1);
   }

   //  Initialize the DCB structure.
   SecureZeroMemory(&dcb, sizeof(DCB));
   dcb.DCBlength = sizeof(DCB);

   //  Build on the current configuration by first retrieving all current
   //  settings.
   fSuccess = GetCommState(hCom, &dcb);

   if (!fSuccess) 
   {
      //  Handle the error.
      printf ("GetCommState failed with error %d.\n", GetLastError());
      return (2);
   }

   PrintCommState(dcb);       //  Output to console

   //  Fill in some DCB values and set the com state: 
   //  57,600 bps, 8 data bits, no parity, and 1 stop bit.
   dcb.BaudRate = CBR_57600;     //  baud rate
   dcb.ByteSize = 8;             //  data size, xmit and rcv
   dcb.Parity   = NOPARITY;      //  parity bit
   dcb.StopBits = ONESTOPBIT;    //  stop bit

   fSuccess = SetCommState(hCom, &dcb);

   if (!fSuccess) 
   {
      //  Handle the error.
      printf ("SetCommState failed with error %d.\n", GetLastError());
      return (3);
   }

   //  Get the comm config again.
   fSuccess = GetCommState(hCom, &dcb);

   if (!fSuccess) 
   {
      //  Handle the error.
      printf ("GetCommState failed with error %d.\n", GetLastError());
      return (2);
   }

   PrintCommState(dcb);       //  Output to console

   _tprintf (TEXT("Serial port %s successfully reconfigured.\n"), pcCommPort);
   return (0);
}

```