### PR TITLE
Remove the openImmediatly flag in favor of the autoOpen option

### DIFF
--- a/examples/opening.js
+++ b/examples/opening.js
@@ -31,7 +31,7 @@
 // When disabling open immediately.
 
 // var SerialPort = require('serialport');
-// var port = new SerialPort('/dev/tty-usbserial1', {}, false);
+// var port = new SerialPort('/dev/tty-usbserial1', { autoOpen: false });
 
 // port.open(function (err) {
 //   if (err) {

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -34,6 +34,7 @@ var kMinPoolSpace = 128;
 
 var defaultSettings = {
   baudRate: 9600,
+  autoOpen: true,
   parity: 'none',
   xon: false,
   xoff: false,
@@ -76,18 +77,17 @@ function correctOptions(options) {
   return options;
 }
 
-function SerialPort(path, options, openImmediately, callback) {
-  var args = Array.prototype.slice.call(arguments);
-  callback = args.pop();
-  if (typeof callback !== 'function') {
-    callback = null;
+function SerialPort(path, options, callback) {
+  if (typeof callback === 'boolean') {
+    throw new TypeError('`openImmediately` is now called `autoOpen` and is a property of options');
   }
 
-  options = (typeof options !== 'function') && options || {};
-
-  if (openImmediately === undefined || openImmediately === null) {
-    openImmediately = true;
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
   }
+
+  options = options || {};
 
   stream.Stream.call(this);
 
@@ -151,7 +151,7 @@ function SerialPort(path, options, openImmediately, callback) {
 
   this.options = settings;
 
-  if (openImmediately) {
+  if (this.options.autoOpen) {
     // is nextTick necessary?
     process.nextTick(this.open.bind(this, callback));
   }

--- a/test/integration-lite.js
+++ b/test/integration-lite.js
@@ -72,7 +72,7 @@ describe('SerialPort light integration', function() {
       });
 
       it('cannot be opened twice', function(done) {
-        var port = new SerialPort(testPort, {}, false);
+        var port = new SerialPort(testPort, { autoOpen: false });
         var calls = 0;
         var errors = 0;
         var spy = function(err) {
@@ -92,7 +92,7 @@ describe('SerialPort light integration', function() {
       });
 
       it('can open and close ports repetitively', function(done) {
-        var port = new SerialPort(testPort, {}, false);
+        var port = new SerialPort(testPort, { autoOpen: false });
         port.open(function(err) {
           assert.isNull(err);
           port.close(function(err) {

--- a/test/serialport.js
+++ b/test/serialport.js
@@ -25,9 +25,18 @@ describe('SerialPort', function() {
     sandbox.restore();
   });
 
-  describe('Legacy Constructor', function() {
-    it('still works', function(done){
+  describe('Depreciated options', function() {
+    it('legacy constructor still works', function(done){
       this.port = new SerialPort.SerialPort('/dev/exists', done);
+    });
+
+    it('throws when `openImmediately` is set', function(done) {
+      try {
+        this.port = new SerialPort('/dev/exists', {}, false);
+      } catch (e) {
+        assert.instanceOf(e, TypeError);
+        done();
+      }
     });
   });
 
@@ -127,9 +136,10 @@ describe('SerialPort', function() {
         xon: true,
         xoff: true,
         xany: true,
-        rtscts: true
+        rtscts: true,
+        autoOpen: false
       };
-      var port = new SerialPort('/dev/exists', options, false);
+      var port = new SerialPort('/dev/exists', options);
       assert.isTrue(port.options.xon);
       assert.isTrue(port.options.xoff);
       assert.isTrue(port.options.xany);
@@ -146,7 +156,7 @@ describe('SerialPort', function() {
     describe('#open', function() {
       it('passes the port to the bindings', function(done) {
         var openSpy = sandbox.spy(bindings, 'open');
-        var port = new SerialPort('/dev/exists', {}, false);
+        var port = new SerialPort('/dev/exists', { autoOpen: false });
         expect(port.isOpen()).to.be.false;
         port.open(function(err) {
           expect(err).to.not.be.ok;
@@ -175,12 +185,12 @@ describe('SerialPort', function() {
           assert.isFunction(cb);
           done();
         });
-        var port = new SerialPort('/dev/exists', {}, false);
+        var port = new SerialPort('/dev/exists', { autoOpen: false });
         port.open();
       });
 
       it('calls back an error when opening an invalid port', function(done) {
-        var port = new SerialPort('/dev/unhappy', {}, false);
+        var port = new SerialPort('/dev/unhappy', { autoOpen: false });
         port.open(function(err) {
           expect(err).to.be.ok;
           done();
@@ -212,7 +222,7 @@ describe('SerialPort', function() {
       });
 
       it('cannot be opened twice', function(done) {
-        var port = new SerialPort('/dev/exists', {}, false);
+        var port = new SerialPort('/dev/exists', { autoOpen: false });
         var calls = 0;
         var errors = 0;
         var spy = function(err) {
@@ -265,7 +275,7 @@ describe('SerialPort', function() {
       });
 
       it('emits an error event or error callback but not both', function(done) {
-        var port = new SerialPort('/dev/exists', false);
+        var port = new SerialPort('/dev/exists', { autoOpen: false });
         var called = 0;
         var doneIfTwice = function(err) {
           assert.instanceOf(err, Error);
@@ -294,7 +304,7 @@ describe('SerialPort', function() {
 
       it('errors when the port is not open', function(done) {
         var cb = function() {};
-        var port = new SerialPort('/dev/exists', false, cb);
+        var port = new SerialPort('/dev/exists', { autoOpen: false }, cb);
         port.close(function(err) {
           assert.instanceOf(err, Error);
           done();
@@ -304,13 +314,13 @@ describe('SerialPort', function() {
 
     describe('#isOpen', function() {
       it('returns false when the port is created', function(done) {
-        var port = new SerialPort('/dev/exists', {}, false);
+        var port = new SerialPort('/dev/exists', { autoOpen: false });
         assert.isFalse(port.isOpen());
         done();
       });
 
       it('returns false when the port is opening', function(done) {
-        var port = new SerialPort('/dev/exists', {}, false);
+        var port = new SerialPort('/dev/exists', { autoOpen: false });
         sandbox.stub(bindings, 'open', function() {
           assert.isTrue(port.opening);
           assert.isFalse(port.isOpen());
@@ -361,7 +371,7 @@ describe('SerialPort', function() {
     describe('#set', function() {
       it('errors when serialport not open', function(done) {
         var cb = function() {};
-        var port = new SerialPort('/dev/exists', {}, false, cb);
+        var port = new SerialPort('/dev/exists', { autoOpen: false }, cb);
         port.set({}, function(err) {
           assert.instanceOf(err, Error);
           done();
@@ -432,7 +442,7 @@ describe('SerialPort', function() {
 
     it('flush errors when serialport not open', function(done) {
       var cb = function() {};
-      var port = new SerialPort('/dev/exists', {}, false, cb);
+      var port = new SerialPort('/dev/exists', { autoOpen: false }, cb);
       port.flush(function(err) {
         assert.instanceOf(err, Error);
         done();
@@ -441,7 +451,7 @@ describe('SerialPort', function() {
 
     it('drain errors when serialport not open', function(done) {
       var cb = function() {};
-      var port = new SerialPort('/dev/exists', {}, false, cb);
+      var port = new SerialPort('/dev/exists', { autoOpen: false }, cb);
       port.drain(function(err) {
         assert.instanceOf(err, Error);
         done();


### PR DESCRIPTION
closes #809

`autoOpen` makes a lot more sense to me. What do you think?