### PR TITLE
Make sure `.drain` and `.set` error on all platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Called once the flush operation returns. The callback should be a function that 
 
 ### .drain (callback)
 
-Waits until all output data has been transmitted to the serial port. See [`tcdrain()`](http://linux.die.net/man/3/tcdrain) for more information.
+Waits until all output data has been transmitted to the serial port. See [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) for more information.
 
 **_callback (optional)_**
 
@@ -441,9 +441,9 @@ All options are operating system default when the port is opened. Every flag is 
 
 **_callback (optional)_**
 
-`callback: function(err, results)`
+`function(err) {}`
 
-Called once the port's flags have been set. `results` are the return of the underlying system command. If `.set` is called without an callback and there is an error, an error event will be emitted.
+Called once the port's flags have been set. If `.set` is called without an callback and there is an error, an error event will be emitted.
 
 ### .update (options, callback)
 

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -452,29 +452,27 @@ SerialPort.prototype.set = function(options, callback) {
     }
   }
 
-  SerialPortBinding.set(this.fd, settings, function(err, result) {
+  SerialPortBinding.set(this.fd, settings, function(err) {
     if (err) {
       debug('SerialPortBinding.set had an error', err);
       return this._error(err, callback);
     }
-    if (callback) { callback(null, result) }
+    if (callback) { callback(null) }
   }.bind(this));
 };
 
 SerialPort.prototype.drain = function(callback) {
-  var fd = this.fd;
-
   if (!this.isOpen()) {
     debug('drain attempted, but port is not open');
     return this._error(new Error('Port is not open'), callback);
   }
 
-  SerialPortBinding.drain(fd, function(err, result) {
+  SerialPortBinding.drain(this.fd, function(err) {
     if (err) {
       debug('SerialPortBinding.drain had an error', err);
       return this._error(err, callback);
     }
-    if (callback) { callback(null, result) }
+    if (callback) { callback(null) }
   }.bind(this));
 };
 

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -572,16 +572,14 @@ void EIO_AfterSet(uv_work_t* req) {
 
   SetBaton* data = static_cast<SetBaton*>(req->data);
 
-  v8::Local<v8::Value> argv[2];
+  v8::Local<v8::Value> argv[1];
 
   if (data->errorString[0]) {
     argv[0] = v8::Exception::Error(Nan::New<v8::String>(data->errorString).ToLocalChecked());
-    argv[1] = Nan::Undefined();
   } else {
-    argv[0] = Nan::Undefined();
-    argv[1] = Nan::New<v8::Int32>(data->result);
+    argv[0] = Nan::Null();
   }
-  data->callback->Call(2, argv);
+  data->callback->Call(1, argv);
 
   delete data->callback;
   delete data;
@@ -620,16 +618,14 @@ void EIO_AfterDrain(uv_work_t* req) {
 
   DrainBaton* data = static_cast<DrainBaton*>(req->data);
 
-  v8::Local<v8::Value> argv[2];
+  v8::Local<v8::Value> argv[1];
 
   if (data->errorString[0]) {
     argv[0] = v8::Exception::Error(Nan::New<v8::String>(data->errorString).ToLocalChecked());
-    argv[1] = Nan::Undefined();
   } else {
-    argv[0] = Nan::Undefined();
-    argv[1] = Nan::New<v8::Int32>(data->result);
+    argv[0] = Nan::Null();
   }
-  data->callback->Call(2, argv);
+  data->callback->Call(1, argv);
 
   delete data->callback;
   delete data;

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -197,7 +197,6 @@ void EIO_Update(uv_work_t* req) {
     ErrorCodeToString("SetCommState", GetLastError(), data->errorString);
     return;
   }
-
 }
 
 void EIO_Set(uv_work_t* req) {
@@ -234,8 +233,11 @@ void EIO_Set(uv_work_t* req) {
   if (data->dsr) {
     bits |= EV_DSR;
   }
-  // TODO check for error
-  data->result = SetCommMask((HANDLE)data->fd, bits);
+
+  if (!SetCommMask((HANDLE)data->fd, bits)) {
+    ErrorCodeToString("Setting options on COM port (SetCommMask)", GetLastError(), data->errorString);
+    return;
+  }
 }
 
 
@@ -532,7 +534,7 @@ void EIO_Flush(uv_work_t* req) {
   FlushBaton* data = static_cast<FlushBaton*>(req->data);
 
   if (!FlushFileBuffers((HANDLE)data->fd)) {
-    ErrorCodeToString("flushing connection", GetLastError(), data->errorString);
+    ErrorCodeToString("flushing connection (FlushFileBuffers)", GetLastError(), data->errorString);
     return;
   }
 }
@@ -541,7 +543,7 @@ void EIO_Drain(uv_work_t* req) {
   DrainBaton* data = static_cast<DrainBaton*>(req->data);
 
   if (!FlushFileBuffers((HANDLE)data->fd)) {
-    ErrorCodeToString("draining connection", GetLastError(), data->errorString);
+    ErrorCodeToString("draining connection (FlushFileBuffers)", GetLastError(), data->errorString);
     return;
   }
 }

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -34,6 +34,15 @@ var defaultPortOpenOptions = {
   disconnectedCallback: function() {}
 };
 
+var defaultSetFlags = {
+  brk: false,
+  cts: false,
+  dtr: true,
+  dts: false,
+  rts: true
+};
+
+
 var testPort = process.env.TEST_PORT;
 
 describe('SerialPortBinding', function() {
@@ -151,9 +160,8 @@ describe('SerialPortBinding', function() {
     });
 
     afterEach(function(done) {
-      var fd = this.fd;
+      SerialPortBinding.close(this.fd, done);
       this.fd = null;
-      SerialPortBinding.close(fd, done);
     });
 
     it('updates baudRate', function(done) {
@@ -189,9 +197,8 @@ describe('SerialPortBinding', function() {
     });
 
     afterEach(function(done) {
-      var fd = this.fd;
+      SerialPortBinding.close(this.fd, done);
       this.fd = null;
-      SerialPortBinding.close(fd, done);
     });
 
     it('calls the write callback once after a small write', function(done){
@@ -206,6 +213,76 @@ describe('SerialPortBinding', function() {
       this.timeout(20000);
       var data = new Buffer(1024 * 5);
       SerialPortBinding.write(this.fd, data, function(err){
+        assert.isNull(err);
+        done();
+      });
+    });
+  });
+
+  describe('#drain', function() {
+    it('errors when given a bad fd', function(done) {
+      SerialPortBinding.drain(44, function(err) {
+        assert.instanceOf(err, Error);
+        done();
+      });
+    });
+
+    if (!testPort) {
+      it('Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.');
+      return;
+    }
+
+    beforeEach(function(done) {
+      SerialPortBinding.open(testPort, defaultPortOpenOptions, function(err, fd) {
+        assert.isNull(err);
+        assert.isNumber(fd);
+        this.fd = fd;
+        done();
+      }.bind(this));
+    });
+
+    afterEach(function(done) {
+      SerialPortBinding.close(this.fd, done);
+      this.fd = null;
+    });
+
+    it('drains the port', function(done) {
+      SerialPortBinding.drain(this.fd, function(err) {
+        assert.isNull(err);
+        done();
+      });
+    });
+  });
+
+  describe('#set', function() {
+    it('errors when given a bad fd', function(done) {
+      SerialPortBinding.drain(44, function(err) {
+        assert.instanceOf(err, Error);
+        done();
+      });
+    });
+
+    if (!testPort) {
+      it('Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.');
+      return;
+    }
+
+    beforeEach(function(done) {
+      SerialPortBinding.open(testPort, defaultPortOpenOptions, function(err, fd) {
+        assert.isNull(err);
+        assert.isNumber(fd);
+        this.fd = fd;
+        done();
+      }.bind(this));
+    });
+
+    afterEach(function(done) {
+      SerialPortBinding.close(this.fd, done);
+      this.fd = null;
+    });
+
+    it('sets flags on the port', function(done) {
+      SerialPortBinding.set(this.fd, defaultSetFlags, function(err) {
         assert.isNull(err);
         done();
       });


### PR DESCRIPTION
Closes a few of #738

closes #729 