### PR TITLE
Make the sample match the rest of the argument documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Opening a serial port:
 ```js
 var SerialPort = require("serialport");
 var port = new SerialPort("/dev/tty-usbserial1", {
-  baudrate: 57600
+  baudRate: 57600
 });
 ```
 


### PR DESCRIPTION
I was confused that it was called ```baudRate``` in ```Port configurtation options``` but shown as ```baudrate``` in the example. Yay for more consistency.