### PR TITLE
Enable locking and sharing of the serialport

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ The system path of the serial port to open. For example, `/dev/tty` on Mac/Linux
 Port configuration options.
 
 * `autoOpen` Automatically opens the port on `nextTick`, defaults to `true`.
+* `lock` Prevent other processes from opening the port, defaults to `true`. `false` is not currently supported on windows.
 * `baudRate` Baud Rate, defaults to 9600. Should be one of: 115200, 57600, 38400, 19200, 9600, 4800, 2400, 1800, 1200, 600, 300, 200, 150, 134, 110, 75, or 50. Custom rates as allowed by hardware is supported. Windows doesn't support custom baud rates.
 * `dataBits` Data Bits, defaults to 8. Must be one of: 8, 7, 6, or 5.
 * `stopBits` Stop Bits, defaults to 1. Must be one of: 1 or 2.

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -44,6 +44,7 @@ var defaultSettings = {
   dataBits: 8,
   stopBits: 1,
   bufferSize: 64 * 1024,
+  lock: true,
   parser: parsers.raw,
   platformOptions: SerialPortBinding.platformOptions
 };

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -137,6 +137,7 @@ NAN_METHOD(Open) {
   baton->xoff = getBoolFromObject(options, "xoff");
   baton->xany = getBoolFromObject(options, "xany");
   baton->hupcl = getBoolFromObject(options, "hupcl");
+  baton->lock = getBoolFromObject(options, "lock");
 
   v8::Local<v8::Object> platformOptions = getValueFromObject(options, "platformOptions")->ToObject();
   baton->platformOptions = ParsePlatformOptions(platformOptions);

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -78,6 +78,7 @@ struct OpenBaton {
   bool xany;
   bool dsrdtr;
   bool hupcl;
+  bool lock;
   Nan::Callback* dataCallback;
   Nan::Callback* disconnectedCallback;
   Nan::Callback* errorCallback;

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -54,15 +54,21 @@ void EIO_Open(uv_work_t* req) {
   strncpy(data->path, "\\\\.\\", 4);
   strncpy(data->path + 4, data->path + 20, 10);
 
+  int shareMode = FILE_SHARE_READ | FILE_SHARE_WRITE;
+  if (data->lock) {
+    shareMode = 0;
+  }
+
   HANDLE file = CreateFile(
     data->path,
     GENERIC_READ | GENERIC_WRITE,
-    0, // dwShareMode 0 Prevents other processes from opening if they request delete, read, or write access
+    shareMode,  // dwShareMode 0 Prevents other processes from opening if they request delete, read, or write access
     NULL,
     OPEN_EXISTING,
-    FILE_FLAG_OVERLAPPED, // allows for reading and writing at the same time and sets the handle for asynchronous I/O
+    FILE_FLAG_OVERLAPPED,  // allows for reading and writing at the same time and sets the handle for asynchronous I/O
     NULL
   );
+
   if (file == INVALID_HANDLE_VALUE) {
     DWORD errorCode = GetLastError();
     char temp[100];


### PR DESCRIPTION
Defaults to locking the port. Unlocking doesn't work on windows yet. Probably needs a security descriptor on top of the sharing settings.

Closes #810 