### PR TITLE
Possibly fix 32 bit binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,14 @@ before_install:
 - nvm install $TRAVIS_NODE_VERSION
 - PATH=$PATH:`pwd`/node_modules/.bin
 
+- BASE_URL=$(node -p "'https://nodejs.org/dist/' + process.version")
+- X86_FILE=$(node -p "'node-' + process.version + '-' + process.platform + '-x86'")
+# download node if testing x86 architecture
+- if [[ "$ARCH" == "x86" ]]; then wget $BASE_URL/$X86_FILE.tar.gz; tar -xf $X86_FILE.tar.gz; export PATH=$X86_FILE/bin:$PATH; fi
+
 # print versions
+- uname -a
+- file `which node`
 - node --version
 - node -p 'process.platform + "@" + process.arch'
 - npm --version


### PR DESCRIPTION
This was something I broke because I didn't understand it. We never had 32 bit vms, only a 32 bit node binary. That is enough to do compile for ia32 it seems.

Closes #836 