### PR TITLE
Do not replace the native Promise when it is available

### DIFF
--- a/lib/list-unix.js
+++ b/lib/list-unix.js
@@ -1,5 +1,9 @@
 'use strict';
-var Promise = require('es6-promise').Promise;
+
+var Promise = typeof global.Promise == 'function'
+  ? global.Promise
+  : require('es6-promise').Promise;
+
 var childProcess = require('child_process');
 var fs = require('fs');
 var path = require('path');

--- a/lib/list-unix.js
+++ b/lib/list-unix.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Promise = typeof global.Promise == 'function'
+var Promise = typeof global.Promise === 'function'
   ? global.Promise
   : require('es6-promise').Promise;
 


### PR DESCRIPTION
Hey guys,

I found a small issue while working with the serialport library. It always replaces the native Promise library with the "es6-promise" shim.

Let me illustrate the problem:

```
$ node
> console.log(Promise);
[Function: Promise]
> require('serialport');
...
> console.log(Promise);
{ [Function: lib$es6$promise$promise$$Promise]
  all: [Function: lib$es6$promise$promise$all$$all],
  race: [Function: lib$es6$promise$promise$race$$race],
  resolve: [Function: lib$es6$promise$promise$resolve$$resolve],
  reject: [Function: lib$es6$promise$promise$reject$$reject],
  _setScheduler: [Function: lib$es6$promise$asap$$setScheduler],
  _setAsap: [Function: lib$es6$promise$asap$$setAsap],
  _asap: [Function: asap] }
```

When it gets replaced some of the code written with the native Promise.defer() function breaks - the "es6-promise" doesn't have it.