### PR TITLE
We no longer have any test ports on windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,8 +62,8 @@ install:
       }
       true;
 
-  # Set a serialport for us to play with
-  - ps: $env:TEST_PORT = "COM1";
+  # We don't currently have a port to test on windows
+  # - ps: $env:TEST_PORT = "COM1";
 
 build_script:
   - npm install --build-from-source --msvs_version=2013


### PR DESCRIPTION
This is unfortunate because we no longer have any light integration tests on windows.

Fixes windows builds.