### PR TITLE
Byte delimiter should emit only when delimiters strictly follow each other

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -2,6 +2,20 @@
 
 // Copyright 2011 Chris Williams <chris@iterativedesigns.com>
 
+function isEqual(arr1, arr2) {
+  var isArray = Array.isArray;
+  if (!isArray(arr1) || !isArray(arr2) || arr1.length !== arr2.length) {
+    return false;
+  }
+  var l = arr1.length;
+  for (var i = 0; i < l; i += 1) {
+    if (arr1[i] !== arr2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 module.exports = {
   raw: function(emitter, buffer) {
     emitter.emit('data', buffer);
@@ -46,19 +60,12 @@ module.exports = {
       delimiter = [ delimiter ];
     }
     var buf = [];
-    var nextDelimIndex = 0;
     return function(emitter, buffer) {
       for (var i = 0; i < buffer.length; i++) {
         buf[buf.length] = buffer[i];
-        if (buf[buf.length - 1] === delimiter[nextDelimIndex]) {
-          nextDelimIndex++;
-        } else {
-          nextDelimIndex = 0;
-        }
-        if (nextDelimIndex === delimiter.length) {
+        if (isEqual(delimiter, buf.slice(-delimiter.length))) {
           emitter.emit('data', buf);
           buf = [];
-          nextDelimIndex = 0;
         }
       }
     };

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -42,7 +42,7 @@ module.exports = {
   // Emit a data event each time a byte sequence (delimiter is an array of byte) is found
   // Sample usage : byteDelimiter([10, 13])
   byteDelimiter: function(delimiter) {
-    if (Object.prototype.toString.call(delimiter) !== '[object Array]') {
+    if (!Array.isArray(delimiter)) {
       delimiter = [ delimiter ];
     }
     var buf = [];
@@ -52,6 +52,8 @@ module.exports = {
         buf[buf.length] = buffer[i];
         if (buf[buf.length - 1] === delimiter[nextDelimIndex]) {
           nextDelimIndex++;
+        } else {
+          nextDelimIndex = 0;
         }
         if (nextDelimIndex === delimiter.length) {
           emitter.emit('data', buf);

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -70,6 +70,14 @@ describe('parsers', function() {
       assert.equal(spy.callCount, 3);
     });
 
+    it('should only emit if delimiters are strictly in row', function() {
+      var data = new Buffer('\0Hello\0World\0\0');
+      var parser = parsers.byteDelimiter([0, 0]);
+      var spy = sinon.spy();
+      parser({ emit: spy }, data);
+      assert.equal(spy.callCount, 1);
+    });
+
     it('continues looking for delimiters in the next buffers', function() {
       var data1 = new Buffer('This could be\0\0binary ');
       var data2 = new Buffer('data\0\0sent from a Moteino\0\0');

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -71,8 +71,8 @@ describe('parsers', function() {
     });
 
     it('should only emit if delimiters are strictly in row', function() {
-      var data = new Buffer('\0Hello\0World\0\0');
-      var parser = parsers.byteDelimiter([0, 0]);
+      var data = new Buffer('\0Hello\u0001World\0\0\u0001');
+      var parser = parsers.byteDelimiter([0, 1]);
       var spy = sinon.spy();
       parser({ emit: spy }, data);
       assert.equal(spy.callCount, 1);


### PR DESCRIPTION
Example:

```
var parser = byteDelimiter([0,0]);

parser(emit, new Buffer('\0hello\0world\0\0');
```

Expected: `emit` should be called once, upon `\0\0` with whole string.
What happens: `emit` is called twice, with `\0hello\0` and `world\0\0`.