### PR TITLE
switch to the lie promise library

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
   parserOptions: {
     sourceType: "script"
   },
+  globals: {
+    "Promise": false
+  },
   rules: {
     "brace-style": [2, "1tbs", {"allowSingleLine": true} ],
     "complexity": [2, 12],

--- a/lib/list-linux.js
+++ b/lib/list-linux.js
@@ -1,8 +1,6 @@
 'use strict';
 
-// requiring es6-promise will replace `Promise` in node, so avoid it if possible
-var Promise = global.Promise || require('es6-promise').Promise;
-
+require('lie/polyfill');
 var childProcess = require('child_process');
 var fs = require('fs');
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "bindings": "1.2.1",
     "commander": "^2.9.0",
     "debug": "^2.1.1",
-    "es6-promise": "^3.2.1",
+    "lie": "^3.1.0",
     "nan": "^2.3.5",
     "node-pre-gyp": "^0.6.26",
     "object.assign": "^4.0.3"


### PR DESCRIPTION
 - it’s smaller by a tiny bit (10k in the node modules, who knows in the bundle)
 - doesn’t have a buggy polyfill
 - mimics the nodejs promise behavior closer with `unhandledRejection` errors