### PR TITLE
Upgrade buffer-indexof

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "bindings": "1.2.1",
-    "buffer-indexof": "^1.0.2",
+    "buffer-indexof": "^1.1.0",
     "commander": "^2.9.0",
     "debug": "^2.1.1",
     "inherits": "^2.0.1",


### PR DESCRIPTION
now completely compliant with latest node 6 buffer.indexOf