### PR TITLE
Plug a hole in the linux/unix read function

### DIFF
--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -345,6 +345,9 @@ if (process.platform !== 'win32') {
 
         // do not emit events if the stream is paused
         if (this.paused) {
+          if (!this.buffer) {
+            this.buffer = new Buffer(0);
+          }
           this.buffer = Buffer.concat([this.buffer, b]);
           return;
         }


### PR DESCRIPTION
`this.buffer` is never initialized so if we close the port while reading we'll get an error. This has no tests but doesn't fail any of our current tests. With the streams rewrite this is no longer an issue and instead of testing it fully here I'd rather concentrate on a new implementation of it.

Closes #925