### PR TITLE
Prevent exception in Buffer.concat, when data starts coming too fast

### DIFF
--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -284,7 +284,11 @@ if (process.platform !== 'win32') {
 
         // do not emit events if the stream is paused
         if (this.paused) {
-          this.buffer = Buffer.concat([this.buffer, b]);
+          if (Buffer.isBuffer(this.buffer)) {
+            this.buffer = Buffer.concat([this.buffer, b]);
+          } else {
+            this.buffer = Buffer.from(b);
+          }
           return;
         }
         this._emitData(b);


### PR DESCRIPTION
Fix issue like this:
```
TypeError: Cannot read property 'length' of undefined
    at Function.Buffer.concat (buffer.js:306:24)
    at SerialPort.<anonymous> (/../node_modules/serialport/lib/serialport.js:348:32)
    at SerialPort.<anonymous> (/../node_modules/serialport/lib/serialport.js:364:7)
    at FSReqWrap.wrapper [as oncomplete] (fs.js:614:17)
uncaughtException: Cannot read property 'length' of undefined
```