### PR TITLE
rename ReadLineParser to ReadlineParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,20 +519,20 @@ The default Parsers are [Transform streams](https://nodejs.org/api/stream.html#s
 | --- | --- | --- |
 | ByteLength | <code>Class</code> | is a transform stream that emits data each time a byte sequence is received. |
 | Delimiter | <code>Class</code> | is a transform stream that emits data as a buffer after a specific number of bytes are received. |
-| ReadLine | <code>Class</code> | is a transform stream that emits data after a newline delimiter is received. |
+| Readline | <code>Class</code> | is a transform stream that emits data after a newline delimiter is received. |
 
 **Example**  
 ```js
 var SerialPort = require('serialport');
-var ReadLine = SerialPort.parsers.ReadLine;
+var Readline = SerialPort.parsers.Readline;
 var port = new SerialPort('/dev/tty-usbserial1');
-var parser = new ReadLine();
+var parser = new Readline();
 port.pipe(parser);
 parser.on('data', console.log);
 port.write('ROBOT PLEASE RESPOND\n');
 
 // creating the parser and piping can be shortened to
-var parser = port.pipe(new ReadLine());
+var parser = port.pipe(new Readline());
 ```
 
 To use the byte length parser, you must provide the length of the number of bytes:
@@ -553,12 +553,12 @@ var parser = port.pipe(new Delimiter({delimiter: new Buffer('EOL')}));
 parser.on('data', console.log);
 ```
 
-To use the ReadLine parser, you may provide a delimiter (defaults to '\n')
+To use the Readline parser, you may provide a delimiter (defaults to '\n')
 ```js
 var SerialPort = require('serialport');
-var ReadLine = SerialPort.parsers.ReadLine;
+var Readline = SerialPort.parsers.Readline;
 var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(ReadLine({delimiter: '\r\n'}));
+var parser = port.pipe(Readline({delimiter: '\r\n'}));
 parser.on('data', console.log);
 ```
 

--- a/lib/parser-readline.js
+++ b/lib/parser-readline.js
@@ -2,9 +2,9 @@
 var DelimiterParser = require('./parser-delimiter');
 var inherits = require('inherits');
 
-function ReadLineParser(options) {
-  if (!(this instanceof ReadLineParser)) {
-    return new ReadLineParser(options);
+function ReadlineParser(options) {
+  if (!(this instanceof ReadlineParser)) {
+    return new ReadlineParser(options);
   }
 
   options = options || {};
@@ -20,5 +20,5 @@ function ReadLineParser(options) {
   this.setEncoding(encoding);
 }
 
-inherits(ReadLineParser, DelimiterParser);
-module.exports = ReadLineParser;
+inherits(ReadlineParser, DelimiterParser);
+module.exports = ReadlineParser;

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -8,19 +8,19 @@
  * @type {object}
  * @property {Class} [ByteLength] is a transform stream that emits data each time a byte sequence is received.
  * @property {Class} [Delimiter] is a transform stream that emits data as a buffer after a specific number of bytes are received.
- * @property {Class} [ReadLine] is a transform stream that emits data after a newline delimiter is received.
+ * @property {Class} [Readline] is a transform stream that emits data after a newline delimiter is received.
  * @example
 ```js
 var SerialPort = require('serialport');
-var ReadLine = SerialPort.parsers.ReadLine;
+var Readline = SerialPort.parsers.Readline;
 var port = new SerialPort('/dev/tty-usbserial1');
-var parser = new ReadLine();
+var parser = new Readline();
 port.pipe(parser);
 parser.on('data', console.log);
 port.write('ROBOT PLEASE RESPOND\n');
 
 // creating the parser and piping can be shortened to
-var parser = port.pipe(new ReadLine());
+var parser = port.pipe(new Readline());
 ```
 
 To use the byte length parser, you must provide the length of the number of bytes:
@@ -41,18 +41,18 @@ var parser = port.pipe(new Delimiter({delimiter: new Buffer('EOL')}));
 parser.on('data', console.log);
 ```
 
-To use the ReadLine parser, you may provide a delimiter (defaults to '\n')
+To use the Readline parser, you may provide a delimiter (defaults to '\n')
 ```js
 var SerialPort = require('serialport');
-var ReadLine = SerialPort.parsers.ReadLine;
+var Readline = SerialPort.parsers.Readline;
 var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(ReadLine({delimiter: '\r\n'}));
+var parser = port.pipe(Readline({delimiter: '\r\n'}));
 parser.on('data', console.log);
 ```
  */
 
 module.exports = {
-  ReadLine: require('./parser-read-line'),
+  Readline: require('./parser-readline'),
   Delimiter: require('./parser-delimiter'),
   ByteLength: require('./parser-byte-length')
 };

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -619,7 +619,7 @@ Object.defineProperty(SerialPort, 'SerialPort', {
   configurable: true
 });
 SerialPort.parsers = {
-  ReadLine: require('./parser-read-line'),
+  Readline: require('./parser-readline'),
   Delimiter: require('./parser-delimiter'),
   ByteLength: require('./parser-byte-length')
 };

--- a/test/parser-readline.js
+++ b/test/parser-readline.js
@@ -3,12 +3,12 @@
 var assert = require('chai').assert;
 var sinon = require('sinon');
 
-var ReadLineParser = require('../lib/parser-read-line');
+var ReadlineParser = require('../lib/parser-readline');
 
-describe('ReadLineParser', function() {
+describe('ReadlineParser', function() {
   it('transforms data to strings split on a delimiter', function() {
     var spy = sinon.spy();
-    var parser = new ReadLineParser();
+    var parser = new ReadlineParser();
     parser.on('data', spy);
     parser.write(new Buffer('I love robots\nEach '));
     parser.write(new Buffer('and Every One\n'));
@@ -23,7 +23,7 @@ describe('ReadLineParser', function() {
 
   it('allows setting of the delimiter with a string', function() {
     var spy = sinon.spy();
-    var parser = new ReadLineParser({delimiter: 'a'});
+    var parser = new ReadlineParser({delimiter: 'a'});
     parser.on('data', spy);
     parser.write(new Buffer('how are youa'));
     assert(spy.calledWith('how '));
@@ -32,7 +32,7 @@ describe('ReadLineParser', function() {
 
   it('allows setting of the delimiter with a buffer', function() {
     var spy = sinon.spy();
-    var parser = new ReadLineParser({delimiter: new Buffer('a')});
+    var parser = new ReadlineParser({delimiter: new Buffer('a')});
     parser.on('data', spy);
     parser.write(new Buffer('how are youa'));
     assert(spy.calledWith('how '));
@@ -41,7 +41,7 @@ describe('ReadLineParser', function() {
 
   it('allows setting of the delimiter with an array of bytes', function() {
     var spy = sinon.spy();
-    var parser = new ReadLineParser({delimiter: [97]});
+    var parser = new ReadlineParser({delimiter: [97]});
     parser.on('data', spy);
     parser.write(new Buffer('how are youa'));
     assert(spy.calledWith('how '));
@@ -50,7 +50,7 @@ describe('ReadLineParser', function() {
 
   it('allows setting of encoding', function() {
     var spy = sinon.spy();
-    var parser = new ReadLineParser({
+    var parser = new ReadlineParser({
       encoding: 'hex'
     });
     parser.on('data', spy);
@@ -61,7 +61,7 @@ describe('ReadLineParser', function() {
 
   it('encoding should be reflected in a string delimiter', function() {
     var spy = sinon.spy();
-    var parser = new ReadLineParser({
+    var parser = new ReadlineParser({
       delimiter: 'FF',
       encoding: 'hex'
     });
@@ -73,39 +73,39 @@ describe('ReadLineParser', function() {
 
   it('throws when called with a 0 length delimiter', function() {
     assert.throws(function() {
-      new ReadLineParser({
+      new ReadlineParser({
         delimiter: new Buffer(0)
       });
     });
 
     assert.throws(function() {
-      new ReadLineParser({
+      new ReadlineParser({
         delimiter: ''
       });
     });
 
     assert.throws(function() {
-      new ReadLineParser({
+      new ReadlineParser({
         delimiter: []
       });
     });
   });
 
   it('allows setting of the delimiter with a string', function() {
-    new ReadLineParser({delimiter: 'string'});
+    new ReadlineParser({delimiter: 'string'});
   });
 
   it('allows setting of the delimiter with a buffer', function() {
-    new ReadLineParser({delimiter: new Buffer([1])});
+    new ReadlineParser({delimiter: new Buffer([1])});
   });
 
   it('allows setting of the delimiter with an array of bytes', function() {
-    new ReadLineParser({delimiter: [1]});
+    new ReadlineParser({delimiter: [1]});
   });
 
   it('doesn\'t emits empty data events', function() {
     var spy = sinon.spy();
-    var parser = new ReadLineParser({delimiter: 'a'});
+    var parser = new ReadlineParser({delimiter: 'a'});
     parser.on('data', spy);
     parser.write(new Buffer('aFa'));
     assert(spy.calledOnce);


### PR DESCRIPTION
matches gnu and nodejs conventions for `readline`

closes #957 