### PR TITLE
Get modem status bits (CTS, DSR, DCD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For getting started with node-serialport, we recommend you begin with the follow
         * [`.list`](#module_serialport--SerialPort.list) : <code>function</code>
     * _inner_
         * [`~errorCallback`](#module_serialport--SerialPort..errorCallback) : <code>function</code>
+        * [`~modemBitsCallback`](#module_serialport--SerialPort..modemBitsCallback) : <code>function</code>
         * [`~openOptions`](#module_serialport--SerialPort..openOptions) : <code>Object</code>
         * [`~listCallback`](#module_serialport--SerialPort..listCallback) : <code>function</code>
 * [Command Line Tools](#command-line-tools)
@@ -292,8 +293,8 @@ Enjoy and do cool things with this code.
 <a name="exp_module_serialport--SerialPort"></a>
 
 ### SerialPort ⏏
-**Kind**: Exported class
-**Emits**: <code>[open](#module_serialport--SerialPort+event_open)</code>, <code>[data](#module_serialport--SerialPort+event_data)</code>, <code>[close](#module_serialport--SerialPort+event_close)</code>, <code>[error](#module_serialport--SerialPort+event_error)</code>, <code>[disconnect](#module_serialport--SerialPort+event_disconnect)</code>
+**Kind**: Exported class  
+**Emits**: <code>[open](#module_serialport--SerialPort+event_open)</code>, <code>[data](#module_serialport--SerialPort+event_data)</code>, <code>[close](#module_serialport--SerialPort+event_close)</code>, <code>[error](#module_serialport--SerialPort+event_error)</code>, <code>[disconnect](#module_serialport--SerialPort+event_disconnect)</code>  
 **Properties**
 
 | Name | Type | Description |
@@ -328,8 +329,8 @@ Create a new serial port object for the `path`. In the case of invalid arguments
 #### `serialPort.open([callback])`
 Opens a connection to the given serial port.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
-**Emits**: <code>[open](#module_serialport--SerialPort+event_open)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Emits**: <code>[open](#module_serialport--SerialPort+event_open)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -343,7 +344,7 @@ Opens a connection to the given serial port.
 #### `serialPort.update([options], [callback])`
 Changes the baud rate for an open port. Throws if you provide a bad argument. Emits an error or calls the callback if the baud rate isn't supported.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -359,7 +360,7 @@ Changes the baud rate for an open port. Throws if you provide a bad argument. Em
 #### `serialPort.write(data, [callback])`
 Some devices like the Arduino reset when you open a connection to them. In these cases if you immediately write to the device they wont be ready to receive the data. This is often worked around by having the Arduino send a "ready" byte that your node program waits for before writing. You can also often get away with waiting around 400ms.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -374,7 +375,7 @@ Some devices like the Arduino reset when you open a connection to them. In these
 #### `serialPort.pause()`
 Pauses an open connection (unix only)
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 -
 
@@ -383,7 +384,7 @@ Pauses an open connection (unix only)
 #### `serialPort.resume()`
 Resumes a paused connection (unix only)
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 -
 
@@ -392,8 +393,8 @@ Resumes a paused connection (unix only)
 #### `serialPort.close(callback)`
 Closes an open connection
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
-**Emits**: <code>[close](#module_serialport--SerialPort+event_close)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Emits**: <code>[close](#module_serialport--SerialPort+event_close)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -407,7 +408,7 @@ Closes an open connection
 #### `serialPort.set([options], [callback])`
 Sets flags on an open port. Uses [`SetCommMask`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363257(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -419,27 +420,30 @@ Sets flags on an open port. Uses [`SetCommMask`](https://msdn.microsoft.com/en-u
 | [options.rts] | <code>Boolean</code> | <code>true</code> |  |
 | [callback] | <code>[errorCallback](#module_serialport--SerialPort..errorCallback)</code> |  | Called once the port's flags have been set. |
 
+
 -
 
 <a name="module_serialport--SerialPort+get"></a>
 
-#### `serialPort.get([options], [callback])`
-Gets flags on an open port. Uses [`GetCommModemStatus`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363258(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
+#### `serialPort.get([callback])`
+Returns the modem status bits (CTS, DSR, DCD) on the open port.
+Uses [`GetCommModemStatus`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363258(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| [callback] | <code>[getCallback](#module_serialport--SerialPort..getCallback)</code> |  | Called once the port's flags have been received. |
+| Param | Type | Description |
+| --- | --- | --- |
+| [callback] | <code>[modemBitsCallback](#module_serialport--SerialPort..modemBitsCallback)</code> | Called once the modem bits have been retrieved. |
 
 
 -
+
 <a name="module_serialport--SerialPort+flush"></a>
 
 #### `serialPort.flush([callback])`
 Flush discards data received but not read and written but not transmitted. For more technical details see [`tcflush(fd, TCIFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -453,13 +457,13 @@ Flush discards data received but not read and written but not transmitted. For m
 #### `serialPort.drain([callback])`
 Waits until all output data has been transmitted to the serial port. See [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) for more information.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | [callback] | <code>[errorCallback](#module_serialport--SerialPort..errorCallback)</code> | Called once the drain operation returns. |
 
-**Example**
+**Example**  
 Writes `data` and waits until it has finish transmitting to the target serial port before calling the callback.
 
 ```
@@ -477,7 +481,7 @@ function writeAndDrain (data, callback) {
 #### `Event: "data"`
 The `data` event's callback is called received data as it's received. If you're using a parser you want to use your parser's `data` event or `read()` function. Data will be a `Buffer` object with a varying amount of data in it. The `readLine` parser will provide a string of a received ASCII or UTF8 line. See the [parsers](#module_serialport--SerialPort.parsers) section for more information.
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 -
 
@@ -486,7 +490,7 @@ The `data` event's callback is called received data as it's received. If you're 
 #### `Event: "error"`
 The `error` event's callback is called with an error object whenever there is an error.
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 -
 
@@ -495,7 +499,7 @@ The `error` event's callback is called with an error object whenever there is an
 #### `Event: "open"`
 The `open` event's callback is called with no arguments when the port is opened and ready for writing. This happens if you have the constructor open immediately (which opens in the next tick) or if you open the port manually with `open()`. See [Useage/Opening a Port](#opening-a-port) for more information.
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 -
 
@@ -504,7 +508,7 @@ The `open` event's callback is called with no arguments when the port is opened 
 #### `Event: "disconnect"`
 The `disconnect` event's callback is called with an error object. This will always happen before a `close` event if a disconnection is detected.
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 -
 
@@ -513,7 +517,7 @@ The `disconnect` event's callback is called with an error object. This will alwa
 #### `Event: "close"`
 The `close` event's callback is called with no arguments when the port is closed. In the event of an error, an error event will be triggered
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 -
 
@@ -524,7 +528,7 @@ The default Parsers are [Transform streams](https://nodejs.org/api/stream.html#s
 
  To use any of the parsers you need to create them and then pipe the serialport to the parser. Be sure not to write to the parser but to the SerialPort object.
 
-**Kind**: static property of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: static property of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 **Properties**
 
 | Name | Type | Description |
@@ -533,7 +537,7 @@ The default Parsers are [Transform streams](https://nodejs.org/api/stream.html#s
 | Delimiter | <code>Class</code> | is a transform stream that emits data as a buffer after a specific number of bytes are received. |
 | ReadLine | <code>Class</code> | is a transform stream that emits data after a newline delimiter is received. |
 
-**Example**
+**Example**  
 ```js
 var SerialPort = require('serialport');
 var ReadLine = SerialPort.parsers.ReadLine;
@@ -581,13 +585,13 @@ parser.on('data', console.log);
 #### `SerialPort.list` : <code>function</code>
 Retrieves a list of available serial ports with metadata. Only the `comName` is guaranteed, all the other fields will be undefined if they are unavailable. The `comName` is either the path or an identifier (eg `COM1`) used to open the serialport.
 
-**Kind**: static property of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: static property of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 | Param | Type |
 | --- | --- |
-| callback | <code>listCallback</code> |
+| callback | <code>listCallback</code> | 
 
-**Example**
+**Example**  
 ```js
 // example port information
 {
@@ -620,11 +624,29 @@ SerialPort.list(function (err, ports) {
 #### `SerialPort~errorCallback` : <code>function</code>
 A callback called with an error or null.
 
-**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 | Param | Type |
 | --- | --- |
-| error | <code>error</code> |
+| error | <code>error</code> | 
+
+
+-
+
+<a name="module_serialport--SerialPort..modemBitsCallback"></a>
+
+#### `SerialPort~modemBitsCallback` : <code>function</code>
+A callback called with an error or an object with the modem line values (cts, dsr, dcd).
+
+**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+
+| Param | Type | Default |
+| --- | --- | --- |
+| error | <code>error</code> |  | 
+| status | <code>object</code> |  | 
+| [status.cts] | <code>boolean</code> | <code>false</code> | 
+| [status.dsr] | <code>boolean</code> | <code>false</code> | 
+| [status.dcd] | <code>boolean</code> | <code>false</code> | 
 
 
 -
@@ -632,7 +654,7 @@ A callback called with an error or null.
 <a name="module_serialport--SerialPort..openOptions"></a>
 
 #### `SerialPort~openOptions` : <code>Object</code>
-**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 **Properties**
 
 | Name | Type | Default | Description |
@@ -660,7 +682,7 @@ A callback called with an error or null.
 #### `SerialPort~listCallback` : <code>function</code>
 This callback type is called `requestCallback` and is displayed as a global symbol.
 
-**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -670,21 +692,6 @@ This callback type is called `requestCallback` and is displayed as a global symb
 
 -
 
-<a name="module_serialport--SerialPort..getCallback"></a>
-
-#### `SerialPort~getCallback` : <code>function</code>
-
-**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
-
-| Param | Type | Description |
-| --- | --- | --- |
-| error | <code>error</code> |  |
-| status | <code>object</code> | an object with boolean values for each flag. |
-| status.cts | <code>Boolean</code> | CTS port value |
-| status.dsr | <code>Boolean</code> | DSR port value |
-| status.dcd | <code>Boolean</code> | DCD port value |
-
--
 
 ## Command Line Tools
 If you install `serialport` globally. (eg, `npm install -g serialport`) you'll receive two command line tools.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ For getting started with node-serialport, we recommend you begin with the follow
         * [`.resume()`](#module_serialport--SerialPort+resume)
         * [`.close(callback)`](#module_serialport--SerialPort+close)
         * [`.set([options], [callback])`](#module_serialport--SerialPort+set)
+        * [`.get([callback])`](#module_serialport--SerialPort+get)
         * [`.flush([callback])`](#module_serialport--SerialPort+flush)
         * [`.drain([callback])`](#module_serialport--SerialPort+drain)
         * [`Event: "data"`](#module_serialport--SerialPort+event_data)
@@ -291,8 +292,8 @@ Enjoy and do cool things with this code.
 <a name="exp_module_serialport--SerialPort"></a>
 
 ### SerialPort ⏏
-**Kind**: Exported class  
-**Emits**: <code>[open](#module_serialport--SerialPort+event_open)</code>, <code>[data](#module_serialport--SerialPort+event_data)</code>, <code>[close](#module_serialport--SerialPort+event_close)</code>, <code>[error](#module_serialport--SerialPort+event_error)</code>, <code>[disconnect](#module_serialport--SerialPort+event_disconnect)</code>  
+**Kind**: Exported class
+**Emits**: <code>[open](#module_serialport--SerialPort+event_open)</code>, <code>[data](#module_serialport--SerialPort+event_data)</code>, <code>[close](#module_serialport--SerialPort+event_close)</code>, <code>[error](#module_serialport--SerialPort+event_error)</code>, <code>[disconnect](#module_serialport--SerialPort+event_disconnect)</code>
 **Properties**
 
 | Name | Type | Description |
@@ -327,8 +328,8 @@ Create a new serial port object for the `path`. In the case of invalid arguments
 #### `serialPort.open([callback])`
 Opens a connection to the given serial port.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
-**Emits**: <code>[open](#module_serialport--SerialPort+event_open)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Emits**: <code>[open](#module_serialport--SerialPort+event_open)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -342,7 +343,7 @@ Opens a connection to the given serial port.
 #### `serialPort.update([options], [callback])`
 Changes the baud rate for an open port. Throws if you provide a bad argument. Emits an error or calls the callback if the baud rate isn't supported.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -358,7 +359,7 @@ Changes the baud rate for an open port. Throws if you provide a bad argument. Em
 #### `serialPort.write(data, [callback])`
 Some devices like the Arduino reset when you open a connection to them. In these cases if you immediately write to the device they wont be ready to receive the data. This is often worked around by having the Arduino send a "ready" byte that your node program waits for before writing. You can also often get away with waiting around 400ms.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -373,7 +374,7 @@ Some devices like the Arduino reset when you open a connection to them. In these
 #### `serialPort.pause()`
 Pauses an open connection (unix only)
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 -
 
@@ -382,7 +383,7 @@ Pauses an open connection (unix only)
 #### `serialPort.resume()`
 Resumes a paused connection (unix only)
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 -
 
@@ -391,8 +392,8 @@ Resumes a paused connection (unix only)
 #### `serialPort.close(callback)`
 Closes an open connection
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
-**Emits**: <code>[close](#module_serialport--SerialPort+event_close)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+**Emits**: <code>[close](#module_serialport--SerialPort+event_close)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -406,7 +407,7 @@ Closes an open connection
 #### `serialPort.set([options], [callback])`
 Sets flags on an open port. Uses [`SetCommMask`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363257(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -418,15 +419,27 @@ Sets flags on an open port. Uses [`SetCommMask`](https://msdn.microsoft.com/en-u
 | [options.rts] | <code>Boolean</code> | <code>true</code> |  |
 | [callback] | <code>[errorCallback](#module_serialport--SerialPort..errorCallback)</code> |  | Called once the port's flags have been set. |
 
-
 -
 
+<a name="module_serialport--SerialPort+get"></a>
+
+#### `serialPort.get([options], [callback])`
+Gets flags on an open port. Uses [`GetCommModemStatus`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363258(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
+
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [callback] | <code>[getCallback](#module_serialport--SerialPort..getCallback)</code> |  | Called once the port's flags have been received. |
+
+
+-
 <a name="module_serialport--SerialPort+flush"></a>
 
 #### `serialPort.flush([callback])`
 Flush discards data received but not read and written but not transmitted. For more technical details see [`tcflush(fd, TCIFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -440,13 +453,13 @@ Flush discards data received but not read and written but not transmitted. For m
 #### `serialPort.drain([callback])`
 Waits until all output data has been transmitted to the serial port. See [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) for more information.
 
-**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: instance method of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
 | [callback] | <code>[errorCallback](#module_serialport--SerialPort..errorCallback)</code> | Called once the drain operation returns. |
 
-**Example**  
+**Example**
 Writes `data` and waits until it has finish transmitting to the target serial port before calling the callback.
 
 ```
@@ -464,7 +477,7 @@ function writeAndDrain (data, callback) {
 #### `Event: "data"`
 The `data` event's callback is called received data as it's received. If you're using a parser you want to use your parser's `data` event or `read()` function. Data will be a `Buffer` object with a varying amount of data in it. The `readLine` parser will provide a string of a received ASCII or UTF8 line. See the [parsers](#module_serialport--SerialPort.parsers) section for more information.
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 -
 
@@ -473,7 +486,7 @@ The `data` event's callback is called received data as it's received. If you're 
 #### `Event: "error"`
 The `error` event's callback is called with an error object whenever there is an error.
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 -
 
@@ -482,7 +495,7 @@ The `error` event's callback is called with an error object whenever there is an
 #### `Event: "open"`
 The `open` event's callback is called with no arguments when the port is opened and ready for writing. This happens if you have the constructor open immediately (which opens in the next tick) or if you open the port manually with `open()`. See [Useage/Opening a Port](#opening-a-port) for more information.
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 -
 
@@ -491,7 +504,7 @@ The `open` event's callback is called with no arguments when the port is opened 
 #### `Event: "disconnect"`
 The `disconnect` event's callback is called with an error object. This will always happen before a `close` event if a disconnection is detected.
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 -
 
@@ -500,7 +513,7 @@ The `disconnect` event's callback is called with an error object. This will alwa
 #### `Event: "close"`
 The `close` event's callback is called with no arguments when the port is closed. In the event of an error, an error event will be triggered
 
-**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: event emitted by <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 -
 
@@ -511,7 +524,7 @@ The default Parsers are [Transform streams](https://nodejs.org/api/stream.html#s
 
  To use any of the parsers you need to create them and then pipe the serialport to the parser. Be sure not to write to the parser but to the SerialPort object.
 
-**Kind**: static property of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: static property of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 **Properties**
 
 | Name | Type | Description |
@@ -520,7 +533,7 @@ The default Parsers are [Transform streams](https://nodejs.org/api/stream.html#s
 | Delimiter | <code>Class</code> | is a transform stream that emits data as a buffer after a specific number of bytes are received. |
 | ReadLine | <code>Class</code> | is a transform stream that emits data after a newline delimiter is received. |
 
-**Example**  
+**Example**
 ```js
 var SerialPort = require('serialport');
 var ReadLine = SerialPort.parsers.ReadLine;
@@ -568,13 +581,13 @@ parser.on('data', console.log);
 #### `SerialPort.list` : <code>function</code>
 Retrieves a list of available serial ports with metadata. Only the `comName` is guaranteed, all the other fields will be undefined if they are unavailable. The `comName` is either the path or an identifier (eg `COM1`) used to open the serialport.
 
-**Kind**: static property of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: static property of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 | Param | Type |
 | --- | --- |
-| callback | <code>listCallback</code> | 
+| callback | <code>listCallback</code> |
 
-**Example**  
+**Example**
 ```js
 // example port information
 {
@@ -607,11 +620,11 @@ SerialPort.list(function (err, ports) {
 #### `SerialPort~errorCallback` : <code>function</code>
 A callback called with an error or null.
 
-**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 | Param | Type |
 | --- | --- |
-| error | <code>error</code> | 
+| error | <code>error</code> |
 
 
 -
@@ -619,7 +632,7 @@ A callback called with an error or null.
 <a name="module_serialport--SerialPort..openOptions"></a>
 
 #### `SerialPort~openOptions` : <code>Object</code>
-**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 **Properties**
 
 | Name | Type | Default | Description |
@@ -647,7 +660,7 @@ A callback called with an error or null.
 #### `SerialPort~listCallback` : <code>function</code>
 This callback type is called `requestCallback` and is displayed as a global symbol.
 
-**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>  
+**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -657,6 +670,21 @@ This callback type is called `requestCallback` and is displayed as a global symb
 
 -
 
+<a name="module_serialport--SerialPort..getCallback"></a>
+
+#### `SerialPort~getCallback` : <code>function</code>
+
+**Kind**: inner typedef of <code>[SerialPort](#exp_module_serialport--SerialPort)</code>
+
+| Param | Type | Description |
+| --- | --- | --- |
+| error | <code>error</code> |  |
+| status | <code>object</code> | an object with boolean values for each flag. |
+| status.cts | <code>Boolean</code> | CTS port value |
+| status.dsr | <code>Boolean</code> | DSR port value |
+| status.dcd | <code>Boolean</code> | DCD port value |
+
+-
 
 ## Command Line Tools
 If you install `serialport` globally. (eg, `npm install -g serialport`) you'll receive two command line tools.

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -21,6 +21,7 @@ module.exports = {
   open: bindings.open,
   SerialportPoller: bindings.SerialportPoller,
   set: bindings.set,
+  get: bindings.get,
   update: bindings.update,
   write: bindings.write,
   platformOptions: platformOptions

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -61,6 +61,16 @@ var defaultSetFlags = {
  * @param {?error} error
  */
 
+ /**
+ * A callback called with an error or an object with the modem line values (cts, dsr, dcd).
+ * @typedef {function} modemBitsCallback
+ * @param {?error} error
+ * @param {?object} status
+ * @param {boolean} [status.cts=false]
+ * @param {boolean} [status.dsr=false]
+ * @param {boolean} [status.dcd=false]
+ */
+
 /**
  * @typedef {Object} openOptions
  * @property {boolean} [autoOpen=true] - Automatically opens the port on `nextTick`
@@ -517,8 +527,9 @@ SerialPort.prototype.set = function(options, callback) {
 };
 
 /**
- * Gets flags on an open port. [`GetCommModemStatus`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363258(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
- * @param {module:serialport~getCallback=} callback Called once the port's flags have been retrieved.
+ * Returns the modem status bits (CTS, DSR, DCD) on the open port.
+ * Uses [`GetCommModemStatus`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363258(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
+ * @param {module:serialport~modemBitsCallback=} callback Called once the modem bits have been retrieved.
  */
 SerialPort.prototype.get = function(callback) {
   if (!this.isOpen) {

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -517,6 +517,25 @@ SerialPort.prototype.set = function(options, callback) {
 };
 
 /**
+ * Gets flags on an open port. [`GetCommModemStatus`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363258(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
+ * @param {module:serialport~getCallback=} callback Called once the port's flags have been retrieved.
+ */
+SerialPort.prototype.get = function(callback) {
+  if (!this.isOpen) {
+    debug('get attempted, but port is not open');
+    return this._error(new Error('Port is not open'), callback);
+  }
+
+  SerialPortBinding.get(this.fd, function(err, status) {
+    if (err) {
+      debug('SerialPortBinding.get had an error', err);
+      return this._error(err, callback);
+    }
+    if (callback) { callback.call(this, null, status) }
+  }.bind(this));
+};
+
+/**
  * Flush discards data received but not read and written but not transmitted. For more technical details see [`tcflush(fd, TCIFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
  * @param  {module:serialport~errorCallback=} callback Called once the flush operation finishes.
  */

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -629,8 +629,8 @@ void EIO_AfterGet(uv_work_t* req) {
 
     v8::Local<v8::Object> results = Nan::New<v8::Object>();
     results->Set(Nan::New<v8::String>("cts").ToLocalChecked(), Nan::New<v8::Boolean>(data->cts));
-    results->Set(Nan::New<v8::String>("dsr").ToLocalChecked(), Nan::New<v8::Boolean>(data->cts));
-    results->Set(Nan::New<v8::String>("dcd").ToLocalChecked(), Nan::New<v8::Boolean>(data->cts));
+    results->Set(Nan::New<v8::String>("dsr").ToLocalChecked(), Nan::New<v8::Boolean>(data->dsr));
+    results->Set(Nan::New<v8::String>("dcd").ToLocalChecked(), Nan::New<v8::Boolean>(data->dcd));
 
     argv[0] = Nan::Null();
     argv[1] = results;

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -39,6 +39,10 @@ NAN_METHOD(Set);
 void EIO_Set(uv_work_t* req);
 void EIO_AfterSet(uv_work_t* req);
 
+NAN_METHOD(Get);
+void EIO_Get(uv_work_t* req);
+void EIO_AfterGet(uv_work_t* req);
+
 NAN_METHOD(Drain);
 void EIO_Drain(uv_work_t* req);
 void EIO_AfterDrain(uv_work_t* req);
@@ -168,6 +172,15 @@ struct SetBaton {
   bool dtr;
   bool dsr;
   bool brk;
+};
+
+struct GetBaton {
+  int fd;
+  Nan::Callback* callback;
+  char errorString[ERROR_STRING_SIZE];
+  bool cts;
+  bool dsr;
+  bool dcd;
 };
 
 struct VoidBaton {

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -714,6 +714,17 @@ void EIO_Set(uv_work_t* req) {
   }
 }
 
+void EIO_Get(uv_work_t* req) {
+  GetBaton* data = static_cast<GetBaton*>(req->data);
+
+  int bits;
+  ioctl(data->fd, TIOCMGET, &bits);
+
+  data->cts = bits & TIOCM_CTS;
+  data->dsr = bits & TIOCM_DSR;
+  data->dcd = bits & TIOCM_CD;
+}
+
 void EIO_Flush(uv_work_t* req) {
   VoidBaton* data = static_cast<VoidBaton*>(req->data);
 

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -247,7 +247,7 @@ void EIO_Set(uv_work_t* req) {
 }
 
 void EIO_Get(uv_work_t* req) {
-  SetBaton* data = static_cast<SetBaton*>(req->data);
+  GetBaton* data = static_cast<GetBaton*>(req->data);
 
   DWORD bits = 0;
   GetCommModemStatus((HANDLE)data->fd, &bits);

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -246,6 +246,16 @@ void EIO_Set(uv_work_t* req) {
   }
 }
 
+void EIO_Get(uv_work_t* req) {
+  SetBaton* data = static_cast<SetBaton*>(req->data);
+
+  DWORD bits = 0;
+  GetCommModemStatus((HANDLE)data->fd, &bits);
+
+  data->cts = bits & MS_CTS_ON;
+  data->dsr = bits & MS_DSR_ON;
+  data->dcd = bits & MS_RLSD_ON;
+}
 
 void EIO_WatchPort(uv_work_t* req) {
   WatchPortBaton* data = static_cast<WatchPortBaton*>(req->data);

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -375,4 +375,43 @@ describe('SerialPortBinding', function() {
       });
     });
   });
+
+  describe('#get', function() {
+    it('errors when given a bad fd', function(done) {
+      SerialPortBinding.drain(44, function(err) {
+        assert.instanceOf(err, Error);
+        done();
+      });
+    });
+
+    if (!testPort) {
+      it('Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.');
+      return;
+    }
+
+    beforeEach(function(done) {
+      SerialPortBinding.open(testPort, defaultPortOpenOptions, function(err, fd) {
+        assert.isNull(err);
+        assert.isNumber(fd);
+        this.fd = fd;
+        done();
+      }.bind(this));
+    });
+
+    afterEach(function(done) {
+      SerialPortBinding.close(this.fd, done);
+      this.fd = null;
+    });
+
+    it('gets modem line status from the port', function(done) {
+      SerialPortBinding.get(this.fd, function(err, status) {
+        assert.isNull(err);
+        assert.isObject(status);
+        assert.isDefined(status.cts);
+        assert.isDefined(status.dsr);
+        assert.isDefined(status.dcd);
+        done();
+      });
+    });
+  });
 });

--- a/test/mocks/darwin-hardware.js
+++ b/test/mocks/darwin-hardware.js
@@ -44,6 +44,7 @@ var Hardware = function() {
     open: this.open.bind(this),
     SerialportPoller: mockSerialportPoller(this),
     set: this.set.bind(this),
+    get: this.get.bind(this),
     update: this.update.bind(this),
     write: this.write.bind(this)
   };
@@ -158,6 +159,18 @@ Hardware.prototype.set = function(fd, options, cb) {
     return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
   }
   callLater(cb, null, undefined);
+};
+
+Hardware.prototype.get = function(fd, cb) {
+  var port = this.fds[fd];
+  if (!port) {
+    return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
+  }
+  callLater(cb, null, {
+    cts: false,
+    dsr: false,
+    dcd: false
+  });
 };
 
 Hardware.prototype.drain = function(fd, cb) {

--- a/test/serialport.js
+++ b/test/serialport.js
@@ -530,6 +530,36 @@ describe('SerialPort', function() {
       });
     });
 
+    describe('#get', function() {
+      it('errors when serialport not open', function(done) {
+        var cb = function() {};
+        var port = new SerialPort('/dev/exists', { autoOpen: false }, cb);
+        port.get(function(err) {
+          assert.instanceOf(err, Error);
+          done();
+        });
+      });
+
+      it('gets the status from the ports bindings', function(done) {
+        var status = {
+          cts: true,
+          dsr: true,
+          dcd: true
+        };
+
+        sandbox.stub(bindings, 'get', function(fd, cb) {
+          cb(status);
+        });
+
+        var port = new SerialPort('/dev/exists', function() {
+          port.get(function(modemStatus) {
+            assert.deepEqual(modemStatus, status);
+            done();
+          });
+        });
+      });
+    });
+
     it('flush errors when serialport not open', function(done) {
       var cb = function() {};
       var port = new SerialPort('/dev/exists', { autoOpen: false }, cb);


### PR DESCRIPTION
Per issue #291, this provides an easy way to get the values of CTS, DSR and DCD using a `get` method (for symmetry with the `set` method). I'm sure it could easily be modified to also provide the current values of the settable bits (brk, dtr, rts)

Apologies for not writing unit tests to go along with this code.

I am currently using this in my [Multi-Bootloader node library](https://github.com/jgillick/node-multibootloader/blob/master/src/multibootloader.js#L119). 

## Example Usage:

```js
var SerialPort = require("serialport");

var port = new SerialPort("/dev/tty-usbserial1", {
  baudRate: 57600
});

port.get((err, status) => {
  if (err) {
    console.error(err);
    return;
  }
  
  console.log('CTS:', status.cts);
  console.log('DSR:', status.dsr);
  console.log('DCD:', status.dcd);
});
```