### PR TITLE
Electron binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,17 @@ addons:
     - g++-4.8
     - g++-4.8-multilib
     - gcc-multilib
+    - libgtk2.0-0
+    - libxtst6
+    - libnotify4
+    - libgconf2-4
+    - libgtk2.0-0:i386
+    - libxtst6:i386
+    - libnotify4:i386
+    - libgconf2-4:i386
+    - libnss3:i386
+    - libasound2:i386
+    - libxss1:i386
 
 # Build matrix
 os:
@@ -18,6 +29,8 @@ env:
   global:
   - secure: "qEdwCY/ilHkqWkqasN5MgWCnzzop4lEYkbpxEiVMTZBY12p4uV6ysPQ+ZLZcx10Cg90RIQlsPeEANIhCzkWfnQi+ySmeiKY9JR2eSnb69wM7dBQ/uxv04eVChAlZSsDHwmTIIzIzZFsrWrcwwJaENGCJYKqZ9LKOiGFGQ8Is09A="
   matrix:
+  - TRAVIS_NODE_VERSION="5"
+  - TRAVIS_NODE_VERSION="5" ARCH="x86"
   - TRAVIS_NODE_VERSION="0.10"
   - TRAVIS_NODE_VERSION="0.10" ARCH="x86"
   - TRAVIS_NODE_VERSION="0.12"
@@ -28,6 +41,8 @@ env:
   - TRAVIS_NODE_VERSION="6" ARCH="x86"
   - TRAVIS_NODE_VERSION="7"
   - TRAVIS_NODE_VERSION="7" ARCH="x86"
+  - TRAVIS_ELECTRON_VERSION="1.4.6" ARCH="x64" TRAVIS_NODE_VERSION="5"
+  - TRAVIS_ELECTRON_VERSION="1.4.6" ARCH="ia32" TRAVIS_NODE_VERSION="5"
 matrix:
   exclude:
   - os: osx
@@ -40,6 +55,8 @@ matrix:
     env: TRAVIS_NODE_VERSION="6" ARCH="x86"
   - os: osx
     env: TRAVIS_NODE_VERSION="7" ARCH="x86"
+  - os: osx
+    env: TRAVIS_ELECTRON_VERSION="1.4.6" ARCH="ia32" TRAVIS_NODE_VERSION="5"
 
 before_install:
 # reinstall latest nvm
@@ -75,16 +92,40 @@ before_install:
 - npm config set progress false
 - npm config set spin false
 
+- >
+  if [[ ! -z $TRAVIS_ELECTRON_VERSION ]]; then
+    if [[ $TRAVIS_OS_NAME == "linux" ]]; then
+      export DISPLAY=:99.0
+      sh -e /etc/init.d/xvfb start
+    fi
+
+    export npm_config_target=$TRAVIS_ELECTRON_VERSION
+    export npm_config_arch=$ARCH
+    export npm_config_disturl=https://atom.io/download/atom-shell
+    export npm_config_runtime=electron
+
+    npm install --arch=$ARCH electron@$TRAVIS_ELECTRON_VERSION
+    npm install electron-mocha
+
+    echo "installed Electron $TRAVIS_ELECTRON_VERSION"
+  fi
+
 install:
 # ensure source install works
 - npm install --build-from-source
+
 
 script:
   # linting no longer works on node 0.10
 - node bin/lower-than-node-4.0.js || npm run lint
 - npm run docs:diff
-- node ./
-- npm test
+- >
+  if [[ -z $TRAVIS_ELECTRON_VERSION ]]; then
+    node ./
+    npm test
+  else
+    electron test/electron
+  fi
 
 # if publishing, do it
 - if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp package; fi;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,10 @@ environment:
   - nodejs_version: "0.12"
   - nodejs_version: "4"
   - nodejs_version: "6"
+  - nodejs_version: "5"
   - nodejs_version: "7"
+  - electron_version: "1.4.6"
+    nodejs_version: "5"
 
 platform:
   - x86
@@ -29,6 +32,7 @@ install:
         "APPVEYOR_REPO_COMMIT_MESSAGE" = $env:APPVEYOR_REPO_COMMIT_MESSAGE
         "git latest tag" = "$(git describe --tags --always HEAD)"
         "appveyor_repo_tag" = $env:appveyor_repo_tag
+        "electron_version" = $env:electron_version
       } | Out-String | Write-Host;
 
   # work around bug in npm 2.15.1 where checksums were coming back bad (node 0.12)
@@ -56,9 +60,9 @@ install:
 
   - ps: >
       if ($env:publish_binary -eq 1) {
-        "We're publising a binary!" | Write-Host
+        "We're publishing a binary!" | Write-Host
       } else {
-        "We're not publising a binary" | Write-Host
+        "We're not publishing a binary" | Write-Host
       }
       true;
 
@@ -69,6 +73,27 @@ install:
 
   # We don't currently have a port to test on windows
   # - ps: $env:TEST_PORT = "COM1";
+
+  # Setup Electron variables
+  - ps: >
+      if ($env:electron_version) {
+        "We're an electron build, setup variables" | Write-Host
+        $env:npm_config_target = $env:electron_version
+        $env:npm_config_disturl = "https://atom.io/download/atom-shell"
+        $env:npm_config_runtime = "electron"
+
+        if ($env:plaftorm -eq "x86") {
+          $env:npm_config_arch = "ia32"
+        } else {
+          $env:npm_config_arch = "x64"
+        }
+
+        "Install electron and electron-mocha" | Write-Host
+
+        npm install -g electron@$env:electron_version
+        npm install electron-mocha
+      }
+      true;
 
 build_script:
   - npm install --build-from-source --msvs_version=2013
@@ -81,8 +106,14 @@ test_script:
         "Not linting because the linter doesn't run on this version of node" | Write-Host
         true;
       }
-  - node ./
-  - npm test
+
+  # If we run npm test in powershell it'll have the wrong encoding
+  # so we have to do it like this
+
+  - IF DEFINED electron_version (electron test/electron)
+  - IF NOT DEFINED electron_version (node ./)
+  - IF NOT DEFINED electron_version (npm test)
+
   - IF %PUBLISH_BINARY% == 1 (node-pre-gyp package 2>&1)
   - IF %PUBLISH_BINARY% == 1 (node-pre-gyp-github publish --release 2>&1)
   - IF %PUBLISH_BINARY% == 1 (node-pre-gyp clean)

--- a/test/electron/main.js
+++ b/test/electron/main.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var app = require('electron').app;
+
+try {
+  var serialport = require('../..'); // eslint-disable-line no-unused-vars
+} catch (e) {
+  console.error('Error loading serialport');
+  console.error(e);
+  app.exit(-1);
+}
+
+app.quit();

--- a/test/electron/package.json
+++ b/test/electron/package.json
@@ -1,0 +1,5 @@
+{
+  "name"    : "your-app",
+  "version" : "0.1.0",
+  "main"    : "main.js"
+}


### PR DESCRIPTION
This is essentially a duplicate of #905, just rebased against the current node-serialport, fixes issue #812. All code credit goes to @suda

A few things to note, it appears the npm test scripts can't be run in a powershell context, the 'tick' is unicode and appveyor's powershell incorrectly encodes it, resulting in failed builds. This is avoided by cmd IF statements instead of powershell if statements.

Electron doesn't run globally, so we can't run regular tests, there's a 'load electron and serialport' test, but perhaps we should increase coverage.

Node 5 is added, since that's what electron is still using.

I've marked 1.4.6 as the latest electron, trivial to add other versions if we need. We should test binary compatibility across electron to get maximum coverage.