### PR TITLE
Remove readable-stream

### DIFF
--- a/lib/parser-byte-length.js
+++ b/lib/parser-byte-length.js
@@ -1,5 +1,5 @@
 'use strict';
-var Transform = require('readable-stream').Transform;
+var Transform = require('stream').Transform;
 var inherits = require('util').inherits;
 
 function ByteLengthParser(options) {

--- a/lib/parser-delimiter.js
+++ b/lib/parser-delimiter.js
@@ -1,5 +1,5 @@
 'use strict';
-var Transform = require('readable-stream').Transform;
+var Transform = require('stream').Transform;
 var inherits = require('util').inherits;
 
 function DelimiterParser(options) {

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -6,7 +6,7 @@
  */
 
 // 3rd Party Dependencies
-var stream = require('readable-stream');
+var stream = require('stream');
 var debug = require('debug')('serialport:main');
 
 // Internal Dependencies

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "commander": "^2.9.0",
     "debug": "^2.3.2",
     "nan": "^2.4.0",
-    "node-pre-gyp": "^0.6.32",
-    "readable-stream": "^2.2.2"
+    "node-pre-gyp": "^0.6.32"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Streams3 are stable in node 4+ so we don't need readable-stream anymore