### PR TITLE
Cover passing bad input to update and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ For getting started with node-serialport, we recommend you begin with the follow
             * [`.close(callback)`](#module_serialport--SerialPort..Binding+close)
             * [`.read(data, length, readCallback)`](#module_serialport--SerialPort..Binding+read)
             * [`.write(data, writeCallback)`](#module_serialport--SerialPort..Binding+write)
+            * [`.update([options], [callback])`](#module_serialport--SerialPort..Binding+update)
             * [`.set([options], callback)`](#module_serialport--SerialPort..Binding+set)
             * [`.get([callback])`](#module_serialport--SerialPort..Binding+get)
             * [`.flush(callback)`](#module_serialport--SerialPort..Binding+flush)
@@ -774,6 +775,7 @@ SerialPort.list(function (err, ports) {
     * [`.close(callback)`](#module_serialport--SerialPort..Binding+close)
     * [`.read(data, length, readCallback)`](#module_serialport--SerialPort..Binding+read)
     * [`.write(data, writeCallback)`](#module_serialport--SerialPort..Binding+write)
+    * [`.update([options], [callback])`](#module_serialport--SerialPort..Binding+update)
     * [`.set([options], callback)`](#module_serialport--SerialPort..Binding+set)
     * [`.get([callback])`](#module_serialport--SerialPort..Binding+get)
     * [`.flush(callback)`](#module_serialport--SerialPort..Binding+flush)
@@ -888,6 +890,26 @@ Write a number of bytes to the SerialPort
 | --- | --- | --- |
 | data | <code>buffer</code> | Accepts a [`Buffer`](http://nodejs.org/api/buffer.html) object. |
 | writeCallback | <code>[errorCallback](#module_serialport--SerialPort..errorCallback)</code> | is called after the data has been passed to the operating system for writing. This will only be called when there isn't a pending write operation. |
+
+
+-
+
+<a name="module_serialport--SerialPort..Binding+update"></a>
+
+##### `binding.update([options], [callback])`
+Changes connection settings on an open port. Currently only the baudRate is required.
+
+**Kind**: instance method of <code>[Binding](#module_serialport--SerialPort..Binding)</code>  
+**Throws**:
+
+- <code>TypeError</code> When given invalid arguments a TypeError will be thrown.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>object</code> | Only `baudRate` is currently supported |
+| [options.baudRate] | <code>number</code> | If provided a baudRate that isn't supported by the bindings it should pass an error to the callback |
+| [callback] | <code>[errorCallback](#module_serialport--SerialPort..errorCallback)</code> | Called once the port's baud rate has been changed. |
 
 
 -

--- a/lib/bindings-auto-detect.js
+++ b/lib/bindings-auto-detect.js
@@ -92,6 +92,15 @@ switch (process.platform) {
  */
 
 /**
+ * Changes connection settings on an open port. Currently only the baudRate is required.
+ * @method module:serialport~Binding#update
+ * @param {object=} options Only `baudRate` is currently supported
+ * @param {number=} [options.baudRate] If provided a baudRate that isn't supported by the bindings it should pass an error to the callback
+ * @param {module:serialport~errorCallback} [callback] Called once the port's baud rate has been changed.
+ * @throws {TypeError} When given invalid arguments a TypeError will be thrown.
+ */
+
+/**
  * Set control flags on an open port.
  * @method module:serialport~Binding#set
  * @param {object=} options All options are operating system default when the port is opened. Every flag is set on each call to the provided or default values. All options will always be provided.
@@ -122,13 +131,5 @@ switch (process.platform) {
  * Drain waits until all output data has been transmitted to the serial port.
  * @method module:serialport~Binding#drain
  * @param  {module:serialport~errorCallback} callback Called once the drain operation finishes.
- * @throws {TypeError} When given invalid arguments a TypeError will be thrown.
- */
-
-/**
- * Changes options on an open port. Currently only the baudRate is required but any option could be passed to the bindings.
- * @param {object=} options Only `baudRate` is currently supported
- * @param {number=} [options.baudRate] If provided a baudRate that isn't supported by the bindings it should pass an error to the callback
- * @param {module:serialport~errorCallback} [callback] Called once the port's baud rate has been changed.
  * @throws {TypeError} When given invalid arguments a TypeError will be thrown.
  */

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -318,6 +318,18 @@ function testBinding(bindingName, Binding, testPort) {
       });
 
       describe('#update', function() {
+        it('throws when not given an object', done => {
+          const binding = new Binding({
+            disconnect
+          });
+          try {
+            binding.update();
+          } catch (e) {
+            assert.instanceOf(e, TypeError);
+            done();
+          }
+        });
+
         it('errors asynchronously when not open', function(done) {
           const binding = new Binding({
             disconnect


### PR DESCRIPTION
doing this to have 100% test coverage on the mock bindings and because the docs were broken