### PR TITLE
Feature flags for disabling tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 language: cpp
 addons:
   apt:
@@ -20,6 +19,7 @@ addons:
     - libnss3:i386
     - libasound2:i386
     - libxss1:i386
+    - socat
 
 # Build matrix
 os:
@@ -81,6 +81,13 @@ before_install:
 # Cleanup the output of npm
 - npm config set progress false
 - npm config set spin false
+
+# setup virtual serialports
+# - >
+  # socat -d -d -unlink-close pty,raw,nonblock,echo=0,link=ttyV0 pty,raw,nonblock,echo=0,link=ttyV1 &
+  # ./bin/echo.js --port ttyV0 &
+  # export TEST_PORT=ttyV1
+  # export DISABLE_PORT_FEATURE=baudrate.25000,set.set,get.get
 
 - >
   if [[ ! -z $TRAVIS_ELECTRON_VERSION ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,6 +92,10 @@ install:
     }
     true;
 
+# Disable windows incompatible port tests
+- ps: >
+    $env:DISABLE_PORT_FEATURE = "open.unlock,baudrate.25000"
+
 build_script:
 - npm install --build-from-source --msvs_version=2013
 

--- a/bin/echo.js
+++ b/bin/echo.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+'use strict';
+
+const SerialPort = require('../');
+const version = require('../package.json').version;
+const args = require('commander');
+
+const readyData = new Buffer('READY');
+
+args
+  .version(version)
+  .usage('-p <port>')
+  .description('A basic terminal interface for communicating over a serial port. Pressing ctrl+c exits.')
+  .option('-p, --port <port>', 'Path or Name of serial port')
+  .parse(process.argv);
+
+if (!args.port) {
+  args.outputHelp();
+  args.missingArgument('port');
+  process.exit(-1);
+}
+
+const port = new SerialPort(args.port);
+
+port.on('open', () => {
+  console.log(`echo: Port open: ${args.port}`);
+  setTimeout(() => {
+    console.log('echo: READY!');
+    port.on('data', data => port.write(data));
+    port.write(readyData);
+  }, 250);
+});

--- a/lib/bindings/mock.js
+++ b/lib/bindings/mock.js
@@ -121,6 +121,7 @@ MockBindings.prototype.open = function(path, opt, cb) {
   }
 
   port.openOpt = opt;
+  port.openOpt = Object.assign({}, opt);
   process.nextTick(() => {
     this.isOpen = true;
     cb(null);


### PR DESCRIPTION
Use feature flags instead of platform tags when disabling tests. This also preps us for virtual ports which don't support every feature.