### PR TITLE
package.json: update node-pre-gyp config

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "binary": {
     "module_name": "serialport",
     "module_path": "build/{configuration}/",
-    "host": "https://github.com/EmergingTechnologyAdvisors/node-serialport/releases/download/4.0.7"
+    "host": "https://github.com",
+    "remote_path": "/EmergingTechnologyAdvisors/node-serialport/releases/download/{version}"
   },
   "main": "./lib/serialport",
   "repository": {


### PR DESCRIPTION
separate `host` and  `remote_path` portions so a mirror location can be provided for private prebuilt binaries.

Fixes #1055