### PR TITLE
package.json: udpate node-pre-gyp params host & remote_path for v5x

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "binary": {
     "module_name": "serialport",
     "module_path": "build/{configuration}/",
-    "host": "https://github.com/EmergingTechnologyAdvisors/node-serialport/releases/download/5.0.0-beta2"
+    "host": "https://github.com",
+    "remote_path": "/EmergingTechnologyAdvisors/node-serialport/releases/download/{version}"
   },
   "main": "./lib",
   "repository": {


### PR DESCRIPTION
to support overriding a host mirror for prebuilt downloads.

Fixes #1055