### PR TITLE
Fix unhandled promise rejection when calling read on Windows.

### DIFF
--- a/lib/bindings/win32.js
+++ b/lib/bindings/win32.js
@@ -36,7 +36,7 @@ class WindowsBinding extends BaseBinding {
 
   read(buffer, offset, length) {
     return super.read(buffer, offset, length)
-      .then(() => promisify(binding.read)(buffer, offset, length));
+      .then(() => promisify(binding.read)(this.fd, buffer, offset, length));
   }
 
   write(buffer) {


### PR DESCRIPTION
Without this change, following error is signaled:
(node:12996) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): TypeError: First argument must be an int