### PR TITLE
add regex stream parser and tests

### DIFF
--- a/lib/parsers/index.js
+++ b/lib/parsers/index.js
@@ -55,5 +55,6 @@ parser.on('data', console.log);
 module.exports = {
   Readline: require('./readline'),
   Delimiter: require('./delimiter'),
-  ByteLength: require('./byte-length')
+  ByteLength: require('./byte-length'),
+  Regex: require('./regex')
 };

--- a/lib/parsers/regex.js
+++ b/lib/parsers/regex.js
@@ -11,7 +11,7 @@ function RegexParser(options) {
   options = options || {};
 
   if (options.delimiter === undefined) {
-    throw new TypeError('"delimiter" is not a RegExp or Bufferable object');
+    throw new TypeError('"delimiter" is not a RegExp object or a string');
   }
 
   if (options.delimiter.length === 0) {
@@ -19,7 +19,7 @@ function RegexParser(options) {
   }
 
   if (!(options.delimiter instanceof RegExp)) {
-    options.delimiter = new RegExp(new Buffer(options.delimiter).toString());
+    options.delimiter = new RegExp(options.delimiter);
   }
 
   const encoding = options.encoding || 'utf8';

--- a/lib/parsers/regex.js
+++ b/lib/parsers/regex.js
@@ -34,12 +34,12 @@ inherits(RegexParser, Transform);
 RegexParser.prototype._transform = function(chunk, encoding, cb) {
   let data = Buffer.concat([this.buffer, chunk]).toString();
 
-  const lines = data.split(this.delimiter);
+  const parts = data.split(this.delimiter);
 
-  data = lines.pop();
+  data = parts.pop();
 
-  lines.forEach((line) => {
-    this.push(line);
+  parts.forEach((part) => {
+    this.push(part);
   });
 
   this.buffer = new Buffer(data);

--- a/lib/parsers/regex.js
+++ b/lib/parsers/regex.js
@@ -1,0 +1,55 @@
+'use strict';
+const inherits = require('util').inherits;
+const Transform = require('stream').Transform;
+
+function RegexParser(options) {
+  if (!(this instanceof RegexParser)) {
+    return new RegexParser(options);
+  }
+  Transform.call(this, options);
+
+  options = options || {};
+
+  if (options.delimiter === undefined) {
+    throw new TypeError('"delimiter" is not a RegExp or Bufferable object');
+  }
+
+  if (options.delimiter.length === 0) {
+    throw new TypeError('"delimiter" has a 0 or undefined length');
+  }
+
+  if (!(options.delimiter instanceof RegExp)) {
+    options.delimiter = new RegExp(new Buffer(options.delimiter).toString());
+  }
+
+  const encoding = options.encoding || 'utf8';
+  this.setEncoding(encoding);
+
+  this.delimiter = options.delimiter;
+  this.buffer = new Buffer(0);
+}
+
+inherits(RegexParser, Transform);
+
+RegexParser.prototype._transform = function(chunk, encoding, cb) {
+  let data = Buffer.concat([this.buffer, chunk]).toString();
+
+  const lines = data.split(this.delimiter);
+
+  data = lines.pop();
+
+  lines.forEach((line) => {
+    this.push(line);
+  });
+
+  this.buffer = new Buffer(data);
+  cb();
+};
+
+RegexParser.prototype._flush = function(cb) {
+  this.push(this.buffer);
+  this.buffer = new Buffer(0);
+  cb();
+};
+
+module.exports = RegexParser;

--- a/test/parser-regex.js
+++ b/test/parser-regex.js
@@ -1,0 +1,145 @@
+'use strict';
+/* eslint-disable no-new */
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+
+const RegexParser = require('../lib/parsers/regex');
+
+describe('RegexParser', () => {
+  it('works without new', () => {
+    // eslint-disable-next-line new-cap
+    const parser = RegexParser({ delimiter: new Buffer([0]) });
+    assert.instanceOf(parser, RegexParser);
+  });
+
+  it('transforms data to strings split on either carriage return or new line', () => {
+    const spy = sinon.spy();
+    const parser = new RegexParser({
+      delimiter: new RegExp(/\r\n|\n\r|\n|\r/)
+    });
+    parser.on('data', spy);
+    parser.write(new Buffer('I love robots\n\rEach '));
+    parser.write(new Buffer('and Every One\r'));
+    parser.write(new Buffer('even you!'));
+
+    assert.deepEqual(spy.getCall(0).args[0], 'I love robots');
+    assert.deepEqual(spy.getCall(1).args[0], 'Each and Every One');
+    assert(spy.calledTwice);
+  });
+
+  it('flushes remaining data when the stream ends', () => {
+    const parser = RegexParser({ delimiter: /\n/ });
+    const spy = sinon.spy();
+    parser.on('data', spy);
+    parser.write(new Buffer([1]));
+    assert.equal(spy.callCount, 0);
+    parser.end();
+    assert.equal(spy.callCount, 1);
+    assert.deepEqual(spy.getCall(0).args[0], new Buffer([1]).toString());
+  });
+
+  it('throws when not provided with a delimiter', () => {
+    assert.throws(() => {
+      new RegexParser({});
+    });
+  });
+
+  it('throws when called with a 0 length delimiter', () => {
+    assert.throws(() => {
+      new RegexParser({
+        delimiter: new Buffer(0)
+      });
+    });
+
+    assert.throws(() => {
+      new RegexParser({
+        delimiter: ''
+      });
+    });
+
+    assert.throws(() => {
+      new RegexParser({
+        delimiter: []
+      });
+    });
+  });
+
+  it('allows setting of the delimiter with a regex string', () => {
+    const spy = sinon.spy();
+    const parser = new RegexParser({ delimiter: 'a|b' });
+    parser.on('data', spy);
+    parser.write('bhow are youa');
+    assert(spy.calledWith('how '));
+    assert(spy.calledWith('re you'));
+  });
+
+  it('allows setting of the delimiter with a buffer', () => {
+    const parser = new RegexParser({ delimiter: new Buffer('a|b') });
+    const spy = sinon.spy();
+    parser.on('data', spy);
+    parser.write('bhow are youa');
+    assert(spy.calledWith('how '));
+    assert(spy.calledWith('re you'));
+  });
+
+  it('allows setting of the delimiter with an array of bytes', () => {
+    const spy = sinon.spy();
+    const parser = new RegexParser({ delimiter: [97, 124, 98] });
+    parser.on('data', spy);
+    parser.write(new Buffer('bhow are youa'));
+    assert(spy.calledWith('how '));
+    assert(spy.calledWith('re you'));
+  });
+
+  it('allows setting of encoding', () => {
+    const spy = sinon.spy();
+    const parser = new RegexParser({
+      delimiter: /\r/,
+      encoding: 'hex'
+    });
+    parser.on('data', spy);
+    parser.write(new Buffer('a\rb\r'));
+    assert.equal(spy.getCall(0).args[0], '61');
+    assert.equal(spy.getCall(1).args[0], '62');
+  });
+
+  it('Works when buffer starts with regex delimiter', () => {
+    const data = new Buffer('\rHello\rWorld\r');
+    const parser = new RegexParser({ delimiter: /\r/ });
+    const spy = sinon.spy();
+    parser.on('data', spy);
+    parser.write(data);
+    assert.equal(spy.callCount, 2);
+  });
+
+  it('should match unicode in buffer string', () => {
+    const data = new Buffer('\u000aHello\u000aWorld\u000d\u000a!');
+    const parser = new RegexParser({ delimiter: /\r\n|\n/ });
+    const spy = sinon.spy();
+    parser.on('data', spy);
+    parser.write(data);
+    assert.equal(spy.callCount, 2);
+  });
+
+  it('continues looking for delimiters in the next buffers', () => {
+    const parser = new RegexParser({ delimiter: /\r\n|\n/ });
+    const spy = sinon.spy();
+    parser.on('data', spy);
+    parser.write(new Buffer('This could be\na poem '));
+    parser.write(new Buffer('or prose\r\nsent from a robot\r\n'));
+    assert.equal(spy.callCount, 3);
+    assert.deepEqual(spy.getCall(0).args[0], 'This could be');
+    assert.deepEqual(spy.getCall(1).args[0], 'a poem or prose');
+    assert.deepEqual(spy.getCall(2).args[0], 'sent from a robot');
+  });
+
+  it('doesn\'t emits empty data events', () => {
+    const spy = sinon.spy();
+    const parser = new RegexParser({ delimiter: /a|b/ });
+    parser.on('data', spy);
+    parser.write(new Buffer('abaFab'));
+    assert(spy.calledOnce);
+    assert(spy.calledWith('F'));
+  });
+});

--- a/test/parser-regex.js
+++ b/test/parser-regex.js
@@ -83,15 +83,6 @@ describe('RegexParser', () => {
     assert(spy.calledWith('re you'));
   });
 
-  it('allows setting of the delimiter with an array of bytes', () => {
-    const spy = sinon.spy();
-    const parser = new RegexParser({ delimiter: [97, 124, 98] });
-    parser.on('data', spy);
-    parser.write(new Buffer('bhow are youa'));
-    assert(spy.calledWith('how '));
-    assert(spy.calledWith('re you'));
-  });
-
   it('allows setting of encoding', () => {
     const spy = sinon.spy();
     const parser = new RegexParser({


### PR DESCRIPTION
Ref to backlog issue: https://github.com/EmergingTechnologyAdvisors/node-serialport/issues/932

This PR adds a regex stream to the available parsers to node-serialport.