### PR TITLE
Write tests for disconnect event on native bindings

### DIFF
--- a/test/bindings.js
+++ b/test/bindings.js
@@ -594,8 +594,25 @@ function testBinding(bindingName, Binding, testPort, disabledFeatures) {
     });
 
     describe('disconnections', () => {
-      it('calls disconnect callback only when detected on a read');
-      it('calls disconnect callback only when detected on a write');
+      let binding;
+      beforeEach(() => {
+        binding = new Binding({ disconnect });
+        return binding.open(testPort, defaultOpenOptions);
+      });
+
+      afterEach(() => binding.close());
+
+      it('calls disconnect callback only when detected on a read', () => {
+        return binding.read(new Buffer(1), 0, 1).then(() => {
+          assert.throws(disconnect);
+        });
+      });
+
+      it('calls disconnect callback only when detected on a write', (done) => {
+        binding.write(new Buffer('test'));
+        assert.throws(disconnect);
+        done();
+      });
     });
   });
 };


### PR DESCRIPTION
This is a reference to this issue: https://github.com/EmergingTechnologyAdvisors/node-serialport/issues/996

Though I'm not sure if just tests were the only component! Nor am I sure they're written correctly 😅