### PR TITLE
Pull out the c++ write queue

### DIFF
--- a/src/serialport.h
+++ b/src/serialport.h
@@ -110,43 +110,6 @@ struct WriteBaton {
   char errorString[ERROR_STRING_SIZE];
 };
 
-struct QueuedWrite {
-  uv_work_t req;
-  QueuedWrite *prev;
-  QueuedWrite *next;
-  WriteBaton* baton;
-
-  QueuedWrite() {
-    prev = this;
-    next = this;
-
-    baton = 0;
-  }
-
-  ~QueuedWrite() {
-    remove();
-  }
-
-  void remove() {
-    prev->next = next;
-    next->prev = prev;
-
-    next = this;
-    prev = this;
-  }
-
-  void insert_tail(QueuedWrite *qw) {
-    qw->next = this;
-    qw->prev = this->prev;
-    qw->prev->next = qw;
-    this->prev = qw;
-  }
-
-  bool empty() {
-    return next == this;
-  }
-};
-
 #ifdef WIN32
 struct ReadBaton {
   int fd;

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -245,8 +245,7 @@ bool IsClosingHandle(int fd) {
 }
 
 void EIO_Write(uv_work_t* req) {
-  QueuedWrite* queuedWrite = static_cast<QueuedWrite*>(req->data);
-  WriteBaton* data = static_cast<WriteBaton*>(queuedWrite->baton);
+  WriteBaton* data = static_cast<WriteBaton*>(req->data);
   data->result = 0;
 
   do {


### PR DESCRIPTION
This shouldn't be necessary now that the stream handles writes, I'm also pretty sure this removes a memory leak on writing where we didn't delete the `QueuedWrite` (notable for backporting)

Passes the arduino test on OSX