### PR TITLE
[unix] Move setting up the baudrate to the end of the open() to better support custom baudrates

### DIFF
--- a/test/bindings.js
+++ b/test/bindings.js
@@ -210,6 +210,14 @@ function testBinding(bindingName, Binding, testPort, localTestConfig) {
           });
         });
 
+        testFeature('baudrate.1000000', 'supports a custom baudRate of 1000000', () => {
+          const customRates = Object.assign({}, defaultOpenOptions, { baudRate: 1000000 });
+          return binding.open(testPort, customRates).then(() => {
+            assert.equal(binding.isOpen, true);
+            return binding.close();
+          });
+        });
+
         describe('optional locking', () => {
           it('locks the port by default', () => {
             const binding2 = new Binding({ disconnect });


### PR DESCRIPTION
- Test 1000000 baud

closes #1077