### PR TITLE
[all] Have drain wait for pending JS write operations before calling system drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Flush discards data received but not read, and written but not transmitted by th
 <a name="module_serialport--SerialPort+drain"></a>
 
 #### `serialPort.drain([callback])`
-Waits until all output data is transmitted to the serial port. See [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) for more information.
+Waits until all output data is transmitted to the serial port. After any pending write has completed it calls [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) to ensure it has been written to the device.
 
 **Kind**: instance method of [<code>SerialPort</code>](#exp_module_serialport--SerialPort)  
 
@@ -607,13 +607,12 @@ Waits until all output data is transmitted to the serial port. See [`tcdrain()`]
 | [callback] | [<code>errorCallback</code>](#module_serialport--SerialPort..errorCallback) | Called once the drain operation returns. |
 
 **Example**  
-Writes `data` and waits until it has finished transmitting to the target serial port before calling the callback.
+Write the `data` and wait until it has finished transmitting to the target serial port before calling the callback.
 
 ```js
 function writeAndDrain (data, callback) {
-  sp.write(data, function () {
-    sp.drain(callback);
-  });
+  port.write(data);
+  port.drain(callback);
 }
 ```
 
@@ -1008,7 +1007,7 @@ Flush (discard) data received but not read, and written but not transmitted.
 <a name="module_serialport--SerialPort..BaseBinding+drain"></a>
 
 ##### `baseBinding.drain()` ⇒ <code>Promise</code>
-Drain waits until all output data is transmitted to the serial port.
+Drain waits until all output data is transmitted to the serial port. An in progress write should be completed before this returns.
 
 **Kind**: instance method of [<code>BaseBinding</code>](#module_serialport--SerialPort..BaseBinding)  
 **Returns**: <code>Promise</code> - Resolves once the drain operation finishes.  

--- a/examples/drain.js
+++ b/examples/drain.js
@@ -2,27 +2,24 @@
 'use strict';
 const Buffer = require('safe-buffer').Buffer;
 const SerialPort = require('serialport');
-const port = new SerialPort('/dev/cu.Cubelet-RGB');
+const port = new SerialPort('/dev/my-great-device');
 
 port.on('open', () => {
   console.log('port opened');
 });
 
-const largeMessage = Buffer.from(1024 * 10).fill('!');
+const largeMessage = Buffer.alloc(1024 * 10, '!');
 port.write(largeMessage, () => {
   console.log('Write callback returned');
-
-  // At this point, data may still be buffered and not sent out over the port yet
-  // write function returns asynchronously even on the system level.
-  console.log('Calling drain');
-  port.drain(() => {
-    console.log('Drain callback returned');
-    // Now the data has "left the pipe" (tcdrain[1]/FlushFileBuffers[2] finished blocking).
-    // [1] http://linux.die.net/man/3/tcdrain
-    // [2] http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aportx
-  });
 });
 
-port.on('data', (data) => {
-  console.log('Received: \t', data);
+// At this point, data may still be buffered in the os or node serialport and not sent
+// out over the port yet. Serialport will wait until any pending writes have completed and then ask
+// the operating system to wait until all data has been written to the file descriptor.
+console.log('Calling drain');
+port.drain(() => {
+  console.log('Drain callback returned');
+  // Now the data has "left the pipe" (tcdrain[1]/FlushFileBuffers[2] finished blocking).
+  // [1] http://linux.die.net/man/3/tcdrain
+  // [2] http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aportx
 });

--- a/lib/bindings/base.js
+++ b/lib/bindings/base.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const debug = require('debug')('serialport:bindings');
 /**
  * @module serialport
  */
@@ -30,6 +30,7 @@ class BaseBinding {
    * @returns {Promise} resolves to an array of port [info objects](#module_serialport--SerialPort.list).
    */
   static list() {
+    debug('list');
     return Promise.resolve();
   }
 
@@ -54,6 +55,7 @@ class BaseBinding {
     if (typeof options !== 'object') {
       throw new TypeError('"options" is not an object');
     }
+    debug('open');
 
     if (this.isOpen) {
       return Promise.reject(new Error('Already open'));
@@ -67,6 +69,7 @@ class BaseBinding {
    * @throws {TypeError} When given invalid arguments, a `TypeError` is thrown.
    */
   close() {
+    debug('close');
     if (!this.isOpen) {
       return Promise.reject(new Error('Port is not open'));
     }
@@ -97,6 +100,7 @@ The in progress reads must error when the port is closed with an error object th
       throw new TypeError('"length" is not an integer');
     }
 
+    debug('read');
     if (buffer.length < offset + length) {
       return Promise.reject(new Error('buffer is too small'));
     }
@@ -121,6 +125,7 @@ The in progress writes must error when the port is closed with an error object t
       throw new TypeError('"buffer" is not a Buffer');
     }
 
+    debug('write', buffer.length, 'bytes');
     if (!this.isOpen) {
       return Promise.reject(new Error('Port is not open'));
     }
@@ -143,6 +148,7 @@ The in progress writes must error when the port is closed with an error object t
       throw new TypeError('"options.baudRate" is not a number');
     }
 
+    debug('update');
     if (!this.isOpen) {
       return Promise.reject(new Error('Port is not open'));
     }
@@ -164,7 +170,7 @@ The in progress writes must error when the port is closed with an error object t
     if (typeof options !== 'object') {
       throw new TypeError('"options" is not an object');
     }
-
+    debug('set');
     if (!this.isOpen) {
       return Promise.reject(new Error('Port is not open'));
     }
@@ -177,6 +183,7 @@ The in progress writes must error when the port is closed with an error object t
    * @throws {TypeError} When given invalid arguments, a `TypeError` is thrown.
    */
   get() {
+    debug('get');
     if (!this.isOpen) {
       return Promise.reject(new Error('Port is not open'));
     }
@@ -189,6 +196,7 @@ The in progress writes must error when the port is closed with an error object t
    * @throws {TypeError} When given invalid arguments, a `TypeError` is thrown.
    */
   flush() {
+    debug('flush');
     if (!this.isOpen) {
       return Promise.reject(new Error('Port is not open'));
     }
@@ -196,11 +204,12 @@ The in progress writes must error when the port is closed with an error object t
   }
 
   /**
-   * Drain waits until all output data is transmitted to the serial port.
+   * Drain waits until all output data is transmitted to the serial port. An in progress write should be completed before this returns.
    * @returns {Promise} Resolves once the drain operation finishes.
    * @throws {TypeError} When given invalid arguments, a `TypeError` is thrown.
    */
   drain() {
+    debug('drain');
     if (!this.isOpen) {
       return Promise.reject(new Error('Port is not open'));
     }

--- a/lib/bindings/darwin.js
+++ b/lib/bindings/darwin.js
@@ -20,6 +20,7 @@ class DarwinBinding extends BaseBinding {
     super(opt);
     this.bindingOptions = Object.assign({}, defaultBindingOptions, opt.bindingOptions || {});
     this.fd = null;
+    this.writeOperation = null;
   }
 
   get isOpen() {
@@ -56,8 +57,12 @@ class DarwinBinding extends BaseBinding {
   }
 
   write(buffer) {
-    return super.write(buffer)
-      .then(() => unixWrite.call(this, buffer));
+    this.writeOperation = super.write(buffer)
+      .then(() => unixWrite.call(this, buffer))
+      .then(() => {
+        this.writeOperation = null;
+      });
+    return this.writeOperation;
   }
 
   update(options) {
@@ -77,6 +82,7 @@ class DarwinBinding extends BaseBinding {
 
   drain() {
     return super.drain()
+      .then(() => Promise.resolve(this.writeOperation))
       .then(() => promisify(binding.drain)(this.fd));
   }
 

--- a/lib/bindings/linux.js
+++ b/lib/bindings/linux.js
@@ -21,6 +21,7 @@ class LinuxBinding extends BaseBinding {
     super(opt);
     this.bindingOptions = Object.assign({}, defaultBindingOptions, opt.bindingOptions || {});
     this.fd = null;
+    this.writeOperation = null;
   }
 
   get isOpen() {
@@ -57,8 +58,12 @@ class LinuxBinding extends BaseBinding {
   }
 
   write(buffer) {
-    return super.write(buffer)
-      .then(() => unixWrite.call(this, buffer));
+    this.writeOperation = super.write(buffer)
+      .then(() => unixWrite.call(this, buffer))
+      .then(() => {
+        this.writeOperation = null;
+      });
+    return this.writeOperation;
   }
 
   update(options) {
@@ -78,6 +83,7 @@ class LinuxBinding extends BaseBinding {
 
   drain() {
     return super.drain()
+      .then(() => Promise.resolve(this.writeOperation))
       .then(() => promisify(binding.drain)(this.fd));
   }
 

--- a/lib/bindings/mock.js
+++ b/lib/bindings/mock.js
@@ -15,6 +15,7 @@ class MockBinding extends BaseBinding {
     this.isOpen = false;
     this.port = null;
     this.lastWrite = null;
+    this.pendingWrite = null;
   }
 
   // Reset mocks
@@ -59,9 +60,9 @@ class MockBinding extends BaseBinding {
     }
     this.port.data = Buffer.concat([this.port.data, data]);
 
-    if (this.port.pendingRead) {
-      process.nextTick(this.port.pendingRead);
-      this.port.pendingRead = null;
+    if (this.pendingRead) {
+      process.nextTick(this.pendingRead);
+      this.pendingRead = null;
     }
   }
 
@@ -117,7 +118,7 @@ class MockBinding extends BaseBinding {
         }
         if (this.port.data.length <= 0) {
           return new Promise((resolve, reject) => {
-            this.port.pendingRead = () => { this.read(buffer, offset, length).then(resolve, reject) };
+            this.pendingRead = () => { this.read(buffer, offset, length).then(resolve, reject) };
           });
         }
         const data = this.port.data.slice(0, length);
@@ -129,7 +130,7 @@ class MockBinding extends BaseBinding {
   }
 
   write(buffer) {
-    return super.write(buffer)
+    this.pendingWrite = super.write(buffer)
       .then(resolveNextTick())
       .then(() => {
         if (!this.isOpen) {
@@ -141,7 +142,9 @@ class MockBinding extends BaseBinding {
             if (this.isOpen) { this.emitData(data) }
           });
         }
+        this.pendingWrite = null;
       });
+    return this.pendingWrite;
   }
 
   update(opt) {
@@ -175,7 +178,15 @@ class MockBinding extends BaseBinding {
   }
 
   drain() {
-    return super.drain();
+    return super.drain()
+      .then(resolveNextTick)
+      .then(() => {
+        return Promise.all([
+          this.pendingRead,
+          this.pendingWrite
+        ]);
+      })
+      .then(() => {});
   }
 }
 

--- a/lib/bindings/unix-read.js
+++ b/lib/bindings/unix-read.js
@@ -5,6 +5,9 @@ const logger = debug('serialport:unixRead');
 
 module.exports = function unixRead(buffer, offset, length) {
   logger('Starting read');
+  if (!this.isOpen) {
+    return Promise.reject(new Error('Port is not open'));
+  }
   return new Promise((resolve, reject) => {
     fs.read(this.fd, buffer, offset, length, null, (err, bytesRead) => {
       if (err && (
@@ -13,7 +16,7 @@ module.exports = function unixRead(buffer, offset, length) {
         err.code === 'EINTR'
       )) {
         if (!this.isOpen) {
-          return reject(new Error('Port has been closed'));
+          return reject(new Error('Port is not open'));
         }
         logger('waiting for readable because of code:', err.code);
         this.poller.once('readable', (err) => {

--- a/lib/bindings/unix-write.js
+++ b/lib/bindings/unix-write.js
@@ -7,15 +7,19 @@ module.exports = function unixWrite(buffer, offset) {
   offset = offset || 0;
   const bytesToWrite = buffer.length - offset;
   logger('Starting write', buffer.length, 'bytes offset', offset, 'bytesToWrite', bytesToWrite);
+  if (!this.isOpen) {
+    return Promise.reject(new Error('Port is not open'));
+  }
   return new Promise((resolve, reject) => {
     fs.write(this.fd, buffer, offset, bytesToWrite, (err, bytesWritten) => {
+      logger('write returned', err, bytesWritten);
       if (err && (
         err.code === 'EAGAIN' ||
         err.code === 'EWOULDBLOCK' ||
         err.code === 'EINTR'
       )) {
         if (!this.isOpen) {
-          return reject(new Error('Port has been closed'));
+          return reject(new Error('Port is not open'));
         }
         logger('waiting for writable because of code:', err.code);
         this.poller.once('writable', (err) => {
@@ -44,6 +48,9 @@ module.exports = function unixWrite(buffer, offset) {
 
       logger('wrote', bytesWritten, 'bytes');
       if (bytesWritten + offset < buffer.length) {
+        if (!this.isOpen) {
+          return reject(new Error('Port is not open'));
+        }
         return resolve(unixWrite.call(this, buffer, bytesWritten + offset));
       }
 

--- a/lib/bindings/win32.js
+++ b/lib/bindings/win32.js
@@ -10,9 +10,9 @@ class WindowsBinding extends BaseBinding {
 
   constructor(opt) {
     super(opt);
-    this.disconnect = opt.disconnect;
     this.bindingOptions = Object.assign({}, opt.bindingOptions || {});
     this.fd = null;
+    this.writeOperation = null;
   }
 
   get isOpen() {
@@ -51,14 +51,12 @@ class WindowsBinding extends BaseBinding {
   }
 
   write(buffer) {
-    return super.write(buffer)
+    this.writeOperation = super.write(buffer)
       .then(() => promisify(binding.write)(this.fd, buffer))
-      .catch(err => {
-        if (!this.isOpen) {
-          err.canceled = true;
-        }
-        throw err;
+      .then(() => {
+        this.writeOperation = null;
       });
+    return this.writeOperation;
   }
 
   update(options) {
@@ -78,6 +76,7 @@ class WindowsBinding extends BaseBinding {
 
   drain() {
     return super.drain()
+      .then(() => Promise.resolve(this.writeOperation))
       .then(() => promisify(binding.drain)(this.fd));
   }
 

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -412,13 +412,15 @@ SerialPort.prototype.close = function(callback, disconnectError) {
   }
 
   this.closing = true;
+  debug('#close');
   this.binding.close().then(() => {
     this.closing = false;
+    debug('binding.close', 'finished');
     this.emit('close', disconnectError);
     if (callback) { callback.call(this, disconnectError) }
   }, (err) => {
     this.closing = false;
-    debug('Binding #close had an error', err);
+    debug('binding.close', 'had an error', err);
     return this._error(err, callback);
   });
 };
@@ -445,11 +447,12 @@ SerialPort.prototype.set = function(options, callback) {
   }
 
   const settings = Object.assign({}, defaultSetFlags, options);
-  debug('set', settings);
+  debug('#set', settings);
   this.binding.set(settings).then(() => {
+    debug('binding.set', 'finished');
     if (callback) { callback.call(this, null) }
   }, (err) => {
-    debug('Binding #set had an error', err);
+    debug('binding.set', 'had an error', err);
     return this._error(err, callback);
   });
 };
@@ -465,11 +468,12 @@ SerialPort.prototype.get = function(callback) {
     return this._asyncError(new Error('Port is not open'), callback);
   }
 
-  debug('get');
+  debug('#get');
   this.binding.get().then((status) => {
+    debug('binding.get', 'finished');
     if (callback) { callback.call(this, null, status) }
   }, (err) => {
-    debug('Binding #get had an error', err);
+    debug('binding.get', 'had an error', err);
     return this._error(err, callback);
   });
 };
@@ -484,26 +488,26 @@ SerialPort.prototype.flush = function(callback) {
     return this._asyncError(new Error('Port is not open'), callback);
   }
 
-  debug('flush');
+  debug('#flush');
   this.binding.flush().then(() => {
+    debug('binding.flush', 'finished');
     if (callback) { callback.call(this, null) }
   }, (err) => {
-    debug('Binding #flush had an error', err);
+    debug('binding.flush', 'had an error', err);
     return this._error(err, callback);
   });
 };
 
 /**
- * Waits until all output data is transmitted to the serial port. See [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) for more information.
+ * Waits until all output data is transmitted to the serial port. After any pending write has completed it calls [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) to ensure it has been written to the device.
  * @param {module:serialport~errorCallback=} callback Called once the drain operation returns.
  * @example
-Writes `data` and waits until it has finished transmitting to the target serial port before calling the callback.
+Write the `data` and wait until it has finished transmitting to the target serial port before calling the callback.
 
 ```js
 function writeAndDrain (data, callback) {
-  sp.write(data, function () {
-    sp.drain(callback);
-  });
+  port.write(data);
+  port.drain(callback);
 }
 ```
  */
@@ -514,9 +518,10 @@ SerialPort.prototype.drain = function(callback) {
   }
   debug('drain');
   this.binding.drain().then(() => {
+    debug('binding.drain', 'finished');
     if (callback) { callback.call(this, null) }
   }, (err) => {
-    debug('Binding #drain had an error', err);
+    debug('binding.drain', 'had an error', err);
     return this._error(err, callback);
   });
 };
@@ -584,6 +589,7 @@ SerialPort.list = function(cb) {
   if (!SerialPort.Binding) {
     throw new TypeError('No Binding set on `SerialPort.Binding`');
   }
+  debug('.list');
   const promise = SerialPort.Binding.list();
   if (typeof cb === 'function') {
     promise.then(

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
+    "bluebird": "^3.5.0",
     "chai": "^4.0.2",
     "chai-subset": "^1.5.0",
     "eslint": "^4.1.1",

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -416,6 +416,17 @@ function testBinding(bindingName, Binding, testPort) {
         it('drains the port', () => {
           return binding.drain();
         });
+
+        it('waits for in progress writes to finish', function(done) {
+          this.timeout(10000);
+          let finishedWrite = false;
+          binding.write(Buffer.alloc(1024 * 2)).then(() => {
+            finishedWrite = true;
+          }).catch(done);
+          binding.drain(() => {
+            assert.isTrue(finishedWrite);
+          }).then(done, done);
+        });
       });
 
       describe('#flush', () => {

--- a/test/initializers/bluebird.js
+++ b/test/initializers/bluebird.js
@@ -1,0 +1,4 @@
+global.Promise = require('bluebird');
+Promise.config({
+  longStackTraces: true
+});


### PR DESCRIPTION
This should allow drain to be a lot more useful.

Bonus:
- More logging!
- Bluebird in tests with it's great long stack traces!

closes #1024