### PR TITLE
[osx] Return the tty instead of the cu for osx serialports

### DIFF
--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -435,7 +435,7 @@ static stDeviceListItem* GetSerialDevices() {
     bsdPathAsCFString = IORegistryEntrySearchCFProperty(
       modemService,
       kIOServicePlane,
-      CFSTR(kIOCalloutDeviceKey),
+      CFSTR(kIODialinDeviceKey),
       kCFAllocatorDefault,
       kIORegistryIterateRecursively);
 


### PR DESCRIPTION
For the record, tty's are `DialinDevice`s and cu's are `CalloutDevice`s

Thanks to @kishinmanglani for helping me solve this!

The closest we could come to docs. https://opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/IOSerialFamily.kmodproj/IOSerialKeys.h

closes #1084 