### PR TITLE
Queue drains

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Waits until all output data is transmitted to the serial port. After any pending
 | [callback] | [<code>errorCallback</code>](#module_serialport--SerialPort..errorCallback) | Called once the drain operation returns. |
 
 **Example**  
-Write the `data` and wait until it has finished transmitting to the target serial port before calling the callback.
+Write the `data` and wait until it has finished transmitting to the target serial port before calling the callback. This will queue until the port is open and writes are finished.
 
 ```js
 function writeAndDrain (data, callback) {

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -4,6 +4,7 @@ Upgrading from 4.x to 5.x
 
 - Removed the `disconnect` event. The `close` event now fires with a disconnect error object in the event of a disconnection.
 - `drain` now waits for the current javascript write to complete before calling the system level drain.
+- `port.isOpen` is now a property not a function
 
 The exact changes will go here see #1046
 

--- a/examples/drain.js
+++ b/examples/drain.js
@@ -8,17 +8,25 @@ port.on('open', () => {
   console.log('port opened');
 });
 
-const largeMessage = Buffer.alloc(1024 * 10, '!');
-port.write(largeMessage, () => {
-  console.log('Write callback returned');
+port.on('error', (error) => {
+  console.error('Oh no error!');
+  console.error(error);
+  process.exit(1);
 });
 
-// At this point, data may still be buffered in the os or node serialport and not sent
-// out over the port yet. Serialport will wait until any pending writes have completed and then ask
-// the operating system to wait until all data has been written to the file descriptor.
+const largeMessage = Buffer.alloc(1024 * 10, '!');
+// Write will wait for the port to open
+port.write(largeMessage, (error) => {
+  console.log('Write callback returned', error);
+  // When this runs data may still be buffered in the os or node serialport and not sent
+  // out over the port yet. Serialport will wait until any pending writes have completed and then ask
+  // the operating system to wait until all data has been written to the file descriptor.
+});
+
 console.log('Calling drain');
-port.drain(() => {
-  console.log('Drain callback returned');
+// Drain will wait for the port to open and the write to finish
+port.drain((error) => {
+  console.log('Drain callback returned', error);
   // Now the data has "left the pipe" (tcdrain[1]/FlushFileBuffers[2] finished blocking).
   // [1] http://linux.die.net/man/3/tcdrain
   // [2] http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aportx

--- a/lib/bindings/mock.js
+++ b/lib/bindings/mock.js
@@ -6,19 +6,19 @@ const BaseBinding = require('./base');
 let ports = {};
 let serialNumber = 0;
 
-function resolveNextTick() {
-  return new Promise(resolve => process.nextTick(resolve));
+function resolveNextTick(value) {
+  return new Promise(resolve => process.nextTick(() => resolve(value)));
 }
 
 class MockBinding extends BaseBinding {
   constructor(opt) {
     super(opt);
-    this.pendingRead = null;
+    this.pendingRead = null; // thunk for a promise or null
     this.isOpen = false;
     this.port = null;
     this.lastWrite = null;
     this.recording = new Buffer(0);
-    this.pendingWrite = null;
+    this.writeOperation = null; // in flight promise or null
   }
 
   // Reset mocks
@@ -100,7 +100,10 @@ class MockBinding extends BaseBinding {
         debug(this.serialNumber, 'port is open');
         if (port.echo) {
           process.nextTick(() => {
-            if (this.isOpen) { this.emitData(port.readyData) }
+            if (this.isOpen) {
+              debug(this.serialNumber, 'emitting ready data');
+              this.emitData(port.readyData);
+            }
           });
         }
       });
@@ -110,7 +113,7 @@ class MockBinding extends BaseBinding {
     const port = this.port;
     debug(this.serialNumber, 'closing port');
     if (!port) {
-      return Promise.reject(new Error('close'));
+      return Promise.reject(new Error('already closed'));
     }
 
     return super.close()
@@ -118,25 +121,30 @@ class MockBinding extends BaseBinding {
         delete port.openOpt;
         // reset data on close
         port.data = Buffer.alloc(0);
-
         debug(this.serialNumber, 'port is closed');
         delete this.port;
         delete this.serialNumber;
         this.isOpen = false;
+        if (this.pendingRead) {
+          this.pendingRead(new Error('port is closed'));
+        }
       });
   }
 
   read(buffer, offset, length) {
     debug(this.serialNumber, 'reading', length, 'bytes');
     return super.read(buffer, offset, length)
-      .then(resolveNextTick())
+      .then(resolveNextTick)
       .then(() => {
         if (!this.isOpen) {
           throw new Error('Read canceled');
         }
         if (this.port.data.length <= 0) {
           return new Promise((resolve, reject) => {
-            this.pendingRead = () => { this.read(buffer, offset, length).then(resolve, reject) };
+            this.pendingRead = (err) => {
+              if (err) { return reject(err) }
+              this.read(buffer, offset, length).then(resolve, reject);
+            };
           });
         }
         const data = this.port.data.slice(0, length);
@@ -149,10 +157,10 @@ class MockBinding extends BaseBinding {
 
   write(buffer) {
     debug(this.serialNumber, 'writing');
-    if (this.pendingWrite) {
+    if (this.writeOperation) {
       throw new Error('Overlapping writes are not supported and should be queued by the serialport object');
     }
-    this.pendingWrite = super.write(buffer)
+    this.writeOperation = super.write(buffer)
       .then(resolveNextTick)
       .then(() => {
         if (!this.isOpen) {
@@ -167,10 +175,10 @@ class MockBinding extends BaseBinding {
             if (this.isOpen) { this.emitData(data) }
           });
         }
-        this.pendingWrite = null;
+        this.writeOperation = null;
         debug(this.serialNumber, 'writing finished');
       });
-    return this.pendingWrite;
+    return this.writeOperation;
   }
 
   update(opt) {
@@ -182,7 +190,8 @@ class MockBinding extends BaseBinding {
   }
 
   set(opt) {
-    return super.set(opt).then(resolveNextTick);
+    return super.set(opt)
+      .then(resolveNextTick);
   }
 
   get() {
@@ -207,14 +216,8 @@ class MockBinding extends BaseBinding {
 
   drain() {
     return super.drain()
-      .then(resolveNextTick)
-      .then(() => {
-        return Promise.all([
-          this.pendingRead,
-          this.pendingWrite
-        ]);
-      })
-      .then(() => {});
+      .then(() => this.writeOperation)
+      .then(() => resolveNextTick());
   }
 }
 

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -502,7 +502,7 @@ SerialPort.prototype.flush = function(callback) {
  * Waits until all output data is transmitted to the serial port. After any pending write has completed it calls [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) to ensure it has been written to the device.
  * @param {module:serialport~errorCallback=} callback Called once the drain operation returns.
  * @example
-Write the `data` and wait until it has finished transmitting to the target serial port before calling the callback.
+Write the `data` and wait until it has finished transmitting to the target serial port before calling the callback. This will queue until the port is open and writes are finished.
 
 ```js
 function writeAndDrain (data, callback) {
@@ -512,11 +512,13 @@ function writeAndDrain (data, callback) {
 ```
  */
 SerialPort.prototype.drain = function(callback) {
-  if (!this.isOpen) {
-    debug('drain attempted, but port is not open');
-    return this._asyncError(new Error('Port is not open'), callback);
-  }
   debug('drain');
+  if (!this.isOpen) {
+    debug('drain queuing on port open');
+    return this.once('open', () => {
+      this.drain(callback);
+    });
+  }
   this.binding.drain().then(() => {
     debug('binding.drain', 'finished');
     if (callback) { callback.call(this, null) }

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -51,21 +51,27 @@ const readyData = Buffer.from('READY');
 
 // Test our mock binding and the binding for the platform we're running on
 bindingsToTest.forEach((bindingName) => {
-  const binding = require(`../lib/bindings/${bindingName}`);
+  const Binding = require(`../lib/bindings/${bindingName}`);
   let testPort = process.env.TEST_PORT;
 
   if (bindingName === 'mock') {
     testPort = '/dev/exists';
-    binding.createPort(testPort, { echo: true, readyData });
   }
 
   // eslint-disable-next-line no-use-before-define
-  testBinding(bindingName, binding, testPort);
+  testBinding(bindingName, Binding, testPort);
 });
 
 function testBinding(bindingName, Binding, testPort) {
   const testFeature = makeTestFeature(bindingName);
+
   describe(`bindings/${bindingName}`, () => {
+    before(() => {
+      if (bindingName === 'mock') {
+        Binding.createPort(testPort, { echo: true, readyData });
+      }
+    });
+
     describe('static method', () => {
       describe('.list', () => {
         it('returns an array', () => {


### PR DESCRIPTION
Drains don't make any sense if called on a closed port or before any writes. I'm queuing drains so they run one the port opens, just like `write()` this allows for a much easier time ensuring all data is written in a script.

- `drain()` waits for an open event if the port is closed
-  mock-bindings now cancel pending reads

closes #1229