### PR TITLE
[all] Change the default high water mark to 64k

### DIFF
--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -28,7 +28,7 @@ const defaultSettings = Object.freeze({
   xany: false,
   xoff: false,
   xon: false,
-  highWaterMark: 16 * 1024
+  highWaterMark: 64 * 1024
 });
 
 const defaultSetFlags = Object.freeze({
@@ -166,7 +166,7 @@ function SerialPort(path, options, callback) {
 
   this.opening = false;
   this.closing = false;
-  this._pool = null;
+  this._pool = allocNewReadPool(this.settings.highWaterMark);
   this._kMinPoolSpace = 128;
 
   if (this.settings.autoOpen) {


### PR DESCRIPTION
The 16k water mark was set a long time ago, 64k is the default for `fs.ReadStream` You should experiment with your application and baudrate.

We also now allocate a buffer pool during object initialization because 99% of the time we'll be doing during runtime and why not take the perf hit upfront instead on first byte.

A side note: The source behind `Buffer.poolSize` and how buffers are allocated and the `ReadStream`'s `BufferList` are fascinating reads. It's obvious a lot of work has gone into these systems.