### PR TITLE
Write/Drain and Readback Manual Test

### DIFF
--- a/test/manual-testing/drain.js
+++ b/test/manual-testing/drain.js
@@ -1,0 +1,36 @@
+/* eslint-disable node/no-missing-require */
+'use strict';
+const Buffer = require('safe-buffer').Buffer;
+const SerialPort = require('../../');
+const port = process.env.TEST_PORT;
+
+if (!port) {
+  console.error('Please pass TEST_PORT environment variable');
+  process.exit(1);
+}
+
+const serialPort = new SerialPort(port, (err) => {
+  if (err) { throw err }
+});
+
+serialPort.on('open', () => {
+  console.log('serialPort opened');
+});
+
+const largeMessage = Buffer.alloc(512, '!');
+console.log(`Writting data dength: ${largeMessage.length} B`);
+serialPort.write(largeMessage, () => {
+  console.log('Write callback returned');
+});
+
+// At this point, data may still be buffered in the os or node serialserialPort and not sent
+// out over the serialPort yet. SerialserialPort will wait until any pending writes have completed and then ask
+// the operating system to wait until all data has been written to the file descriptor.
+console.log('Calling drain');
+serialPort.drain(() => {
+  console.log('Drain callback returned');
+  // Now the data has "left the pipe" (tcdrain[1]/FlushFileBuffers[2] finished blocking).
+  // [1] http://linux.die.net/man/3/tcdrain
+  // [2] http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aserialPortx
+});
+// });

--- a/test/manual-testing/drain.js
+++ b/test/manual-testing/drain.js
@@ -3,6 +3,8 @@
 const Buffer = require('safe-buffer').Buffer;
 const SerialPort = require('../../');
 const port = process.env.TEST_PORT;
+// number of bytes to send
+const size = 512;
 
 if (!port) {
   console.error('Please pass TEST_PORT environment variable');
@@ -10,14 +12,14 @@ if (!port) {
 }
 
 const serialPort = new SerialPort(port, (err) => {
-  if (err) { throw err }
+  if (err) { throw err };
 });
 
 serialPort.on('open', () => {
   console.log('serialPort opened');
 });
 
-const largeMessage = Buffer.alloc(512, '!');
+const largeMessage = Buffer.alloc(size, '!');
 console.log(`Writting data dength: ${largeMessage.length} B`);
 serialPort.write(largeMessage, () => {
   console.log('Write callback returned');
@@ -33,4 +35,3 @@ serialPort.drain(() => {
   // [1] http://linux.die.net/man/3/tcdrain
   // [2] http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aserialPortx
 });
-// });

--- a/test/manual-testing/drain.js
+++ b/test/manual-testing/drain.js
@@ -25,13 +25,7 @@ serialPort.write(largeMessage, () => {
   console.log('Write callback returned');
 });
 
-// At this point, data may still be buffered in the os or node serialserialPort and not sent
-// out over the serialPort yet. SerialserialPort will wait until any pending writes have completed and then ask
-// the operating system to wait until all data has been written to the file descriptor.
 console.log('Calling drain');
 serialPort.drain(() => {
   console.log('Drain callback returned');
-  // Now the data has "left the pipe" (tcdrain[1]/FlushFileBuffers[2] finished blocking).
-  // [1] http://linux.die.net/man/3/tcdrain
-  // [2] http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aserialPortx
 });

--- a/test/manual-testing/read.js
+++ b/test/manual-testing/read.js
@@ -1,0 +1,40 @@
+/* eslint-disable node/no-missing-require */
+'use strict';
+const SerialPort = require('../../');
+const port = process.env.TEST_PORT_RX;
+const { exec } = require('child_process');
+
+const expected = 512;
+
+if (!port) {
+  console.error('Please pass TEST_PORT environment variable');
+  process.exit(1);
+}
+
+const serialPort = new SerialPort(port, (err) => {
+  if (err) { throw err }
+  exec('node drain.js', (err, stdout) => {
+    if (err) {
+      // node couldn't execute the command
+      process.exit(1);
+    }
+
+    console.log(stdout);
+
+    setTimeout(() => {
+      serialPort.on('data', (data) => {
+        console.log(`Recieved data dength: ${data.length} B`);
+        if (data.length === expected) {
+          process.exit(0);
+        } else {
+          process.exit(1);
+        }
+      });
+    }, 100);
+
+    setTimeout(() => {
+      console.log('Receive data timeout');
+      process.exit(1);
+    }, 1000);
+  });
+});

--- a/test/manual-testing/read.js
+++ b/test/manual-testing/read.js
@@ -1,14 +1,13 @@
 /* eslint-disable node/no-missing-require */
 'use strict';
 const SerialPort = require('../../');
+const ByteLength = SerialPort.parsers.ByteLength;
 const exec = require('child_process').exec;
 
 // Serial receiver device 
 const port = process.env.TEST_PORT_RX;
 // Expected number of bytes to receive (should make `size` in drain.js)
 const expected = 512;
-const ByteLength = SerialPort.parsers.ByteLength;
-const parser = port.pipe(new ByteLength({ length: expected }));
 
 if (!port) {
   console.error('Please pass TEST_PORT_RX environment variable');
@@ -29,6 +28,7 @@ serialPort.on('open', () => {
     }
 
     console.log(stdout);
+    const parser = serialPort.pipe(new ByteLength({ length: expected }));
 
     // Read back the data received on the read device after a short timout to ensure transmission
     parser.on('data', (data) => {

--- a/test/manual-testing/read.js
+++ b/test/manual-testing/read.js
@@ -1,9 +1,11 @@
 /* eslint-disable node/no-missing-require */
 'use strict';
 const SerialPort = require('../../');
-const port = process.env.TEST_PORT_RX;
 const { exec } = require('child_process');
 
+// Serial receiver device 
+const port = process.env.TEST_PORT_RX;
+// Expected number of bytes to receive (should make `size` in drain.js)
 const expected = 512;
 
 if (!port) {
@@ -11,8 +13,11 @@ if (!port) {
   process.exit(1);
 }
 
+// Create read device
 const serialPort = new SerialPort(port, (err) => {
   if (err) { throw err }
+
+  // Run the drain script from the sender device
   exec('node drain.js', (err, stdout) => {
     if (err) {
       // node couldn't execute the command
@@ -21,6 +26,7 @@ const serialPort = new SerialPort(port, (err) => {
 
     console.log(stdout);
 
+    // Read back the data received on the read device after a short timout to ensure transmission
     setTimeout(() => {
       serialPort.on('data', (data) => {
         console.log(`Recieved data dength: ${data.length} B`);
@@ -32,9 +38,10 @@ const serialPort = new SerialPort(port, (err) => {
       });
     }, 100);
 
+    // Set a timeout so the process exits if no data received
     setTimeout(() => {
       console.log('Receive data timeout');
       process.exit(1);
-    }, 1000);
+    }, 10000);
   });
 });


### PR DESCRIPTION
Following #1229, I've added two files to manual-testing to verify the operation of `write()` and in particular, `drain()` events.

The the uses two USB serial devices to form a loopback test. I've used an additional environment variable `TEST_PORT_RX` to denote the receiver. Example usage:

`TEST_PORT=/dev/ttyUSB0 TEST_PORT_RX=/dev/ttyUSB1 DEBUG=* node read.js`

TX from `TEST_PORT` should be connected to RX on `TEST_PORT_RX`.

It will exit with ok (0) if number of bytes received matches number of bytes expected, otherwise error (1). Console log messages show sent data length and received data length. The script should be called from the script directory due to the child process calling the drain.js script explicitly - might be worth changing this to pass CWD.