### PR TITLE
[unix] fix a bug when poller errors would be unhandled

### DIFF
--- a/lib/bindings/poller.js
+++ b/lib/bindings/poller.js
@@ -13,7 +13,10 @@ const EVENTS = {
 function handleEvent(error, eventFlag) {
   if (error) {
     logger('error', error);
-    return this.emit('error', error);
+    this.emit('readable', error);
+    this.emit('writable', error);
+    this.emit('disconnect', error);
+    return;
   }
   if (eventFlag & EVENTS.UV_READABLE) {
     logger('received "readable"');


### PR DESCRIPTION
They will now be handled by the reads and writes that use it.

Reported by @thiago-sylvain

Closes #1243