### PR TITLE
[all] Change parsers to be es6 classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,52 +723,62 @@ The default `Parsers` are [Transform streams](https://nodejs.org/api/stream.html
 
 **Example**  
 ```js
-var SerialPort = require('serialport');
-var Readline = SerialPort.parsers.Readline;
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = new Readline();
+const SerialPort = require('serialport');
+const Readline = SerialPort.parsers.Readline;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = new Readline();
 port.pipe(parser);
 parser.on('data', console.log);
 port.write('ROBOT PLEASE RESPOND\n');
 
 // Creating the parser and piping can be shortened to
-var parser = port.pipe(new Readline());
+// const parser = port.pipe(new Readline());
 ```
 
 To use the `ByteLength` parser, provide the length of the number of bytes:
 ```js
-var SerialPort = require('serialport');
-var ByteLength = SerialPort.parsers.ByteLength
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(new ByteLength({length: 8}));
+const SerialPort = require('serialport');
+const ByteLength = SerialPort.parsers.ByteLength
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(new ByteLength({length: 8}));
 parser.on('data', console.log);
 ```
 
 To use the `Delimiter` parser, provide a delimiter as a string, buffer, or array of bytes:
 ```js
-var SerialPort = require('serialport');
-var Delimiter = SerialPort.parsers.Delimiter;
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(new Delimiter({delimiter: Buffer.from('EOL')}));
+const SerialPort = require('serialport');
+const Delimiter = SerialPort.parsers.Delimiter;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(new Delimiter({ delimiter: Buffer.from('EOL') }));
 parser.on('data', console.log);
 ```
 
-To use the `Readline` parser, provide a delimiter (defaults to '\n')
+To use the `Readline` parser, provide a delimiter (defaults to '\n'). Data is emitted as string controllable by the `encoding` option (defaults to `utf8`).
 ```js
-var SerialPort = require('serialport');
-var Readline = SerialPort.parsers.Readline;
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(Readline({delimiter: '\r\n'}));
+const SerialPort = require('serialport');
+const Readline = SerialPort.parsers.Readline;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(Readline({ delimiter: '\r\n' }));
 parser.on('data', console.log);
 ```
 
-To use the `Ready` parser provide a byte start sequence. After the bytes have been received data events will be passed through.
+To use the `Ready` parser provide a byte start sequence. After the bytes have been received data events are passed through.
 ```js
-var SerialPort = require('serialport');
-var Ready = SerialPort.parsers.Ready;
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(Ready({data: 'READY'}));
+const SerialPort = require('serialport');
+const Ready = SerialPort.parsers.Ready;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(Ready({ data: 'READY' }));
+parser.on('ready', () => console.log('the ready byte sequence has been received'))
 parser.on('data', console.log); // all data after READY is received
+```
+
+To use the `Regex` parser provide a regular expression to split the incoming text upon. Data is emitted as string controllable by the `encoding` option (defaults to `utf8`).
+```js
+const SerialPort = require('serialport');
+const Regex = SerialPort.parsers.Regex;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(Regex({ regex: /[\r\n]+/ }));
+parser.on('data', console.log);
 ```
 
 * * *

--- a/lib/parsers/byte-length.js
+++ b/lib/parsers/byte-length.js
@@ -1,45 +1,38 @@
 'use strict';
 const Buffer = require('safe-buffer').Buffer;
-const inherits = require('util').inherits;
 const Transform = require('stream').Transform;
 
-function ByteLengthParser(options) {
-  if (!(this instanceof ByteLengthParser)) {
-    return new ByteLengthParser(options);
+module.exports = class ByteLengthParser extends Transform {
+  constructor(options) {
+    super(options);
+    options = options || {};
+
+    if (typeof options.length !== 'number') {
+      throw new TypeError('"length" is not a number');
+    }
+
+    if (options.length < 1) {
+      throw new TypeError('"length" is not greater than 0');
+    }
+
+    this.length = options.length;
+    this.buffer = Buffer.alloc(0);
   }
-  Transform.call(this, options);
 
-  options = options || {};
-
-  if (typeof options.length !== 'number') {
-    throw new TypeError('"length" is not a number');
+  _transform(chunk, encoding, cb) {
+    let data = Buffer.concat([this.buffer, chunk]);
+    while (data.length >= this.length) {
+      const out = data.slice(0, this.length);
+      this.push(out);
+      data = data.slice(this.length);
+    }
+    this.buffer = data;
+    cb();
   }
 
-  if (options.length < 1) {
-    throw new TypeError('"length" is not greater than 0');
+  _flush(cb) {
+    this.push(this.buffer);
+    this.buffer = Buffer.alloc(0);
+    cb();
   }
-
-  this.length = options.length;
-  this.buffer = Buffer.alloc(0);
-}
-
-inherits(ByteLengthParser, Transform);
-
-ByteLengthParser.prototype._transform = function(chunk, encoding, cb) {
-  let data = Buffer.concat([this.buffer, chunk]);
-  while (data.length >= this.length) {
-    const out = data.slice(0, this.length);
-    this.push(out);
-    data = data.slice(this.length);
-  }
-  this.buffer = data;
-  cb();
 };
-
-ByteLengthParser.prototype._flush = function(cb) {
-  this.push(this.buffer);
-  this.buffer = Buffer.alloc(0);
-  cb();
-};
-
-module.exports = ByteLengthParser;

--- a/lib/parsers/delimiter.js
+++ b/lib/parsers/delimiter.js
@@ -1,45 +1,38 @@
 'use strict';
 const Buffer = require('safe-buffer').Buffer;
-const inherits = require('util').inherits;
 const Transform = require('stream').Transform;
 
-function DelimiterParser(options) {
-  if (!(this instanceof DelimiterParser)) {
-    return new DelimiterParser(options);
+module.exports = class DelimiterParser extends Transform {
+  constructor(options) {
+    options = options || {};
+    super(options);
+
+    if (options.delimiter === undefined) {
+      throw new TypeError('"delimiter" is not a bufferable object');
+    }
+
+    if (options.delimiter.length === 0) {
+      throw new TypeError('"delimiter" has a 0 or undefined length');
+    }
+
+    this.delimiter = Buffer.from(options.delimiter);
+    this.buffer = Buffer.alloc(0);
   }
-  Transform.call(this, options);
 
-  options = options || {};
-
-  if (options.delimiter === undefined) {
-    throw new TypeError('"delimiter" is not a bufferable object');
+  _transform(chunk, encoding, cb) {
+    let data = Buffer.concat([this.buffer, chunk]);
+    let position;
+    while ((position = data.indexOf(this.delimiter)) !== -1) {
+      this.push(data.slice(0, position));
+      data = data.slice(position + this.delimiter.length);
+    }
+    this.buffer = data;
+    cb();
   }
 
-  if (options.delimiter.length === 0) {
-    throw new TypeError('"delimiter" has a 0 or undefined length');
+  _flush(cb) {
+    this.push(this.buffer);
+    this.buffer = Buffer.alloc(0);
+    cb();
   }
-
-  this.delimiter = Buffer.from(options.delimiter);
-  this.buffer = Buffer.alloc(0);
-}
-
-inherits(DelimiterParser, Transform);
-
-DelimiterParser.prototype._transform = function(chunk, encoding, cb) {
-  let data = Buffer.concat([this.buffer, chunk]);
-  let position;
-  while ((position = data.indexOf(this.delimiter)) !== -1) {
-    this.push(data.slice(0, position));
-    data = data.slice(position + this.delimiter.length);
-  }
-  this.buffer = data;
-  cb();
 };
-
-DelimiterParser.prototype._flush = function(cb) {
-  this.push(this.buffer);
-  this.buffer = Buffer.alloc(0);
-  cb();
-};
-
-module.exports = DelimiterParser;

--- a/lib/parsers/index.js
+++ b/lib/parsers/index.js
@@ -12,59 +12,69 @@
  * @since 5.0.0
  * @example
 ```js
-var SerialPort = require('serialport');
-var Readline = SerialPort.parsers.Readline;
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = new Readline();
+const SerialPort = require('serialport');
+const Readline = SerialPort.parsers.Readline;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = new Readline();
 port.pipe(parser);
 parser.on('data', console.log);
 port.write('ROBOT PLEASE RESPOND\n');
 
 // Creating the parser and piping can be shortened to
-var parser = port.pipe(new Readline());
+// const parser = port.pipe(new Readline());
 ```
 
 To use the `ByteLength` parser, provide the length of the number of bytes:
 ```js
-var SerialPort = require('serialport');
-var ByteLength = SerialPort.parsers.ByteLength
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(new ByteLength({length: 8}));
+const SerialPort = require('serialport');
+const ByteLength = SerialPort.parsers.ByteLength
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(new ByteLength({length: 8}));
 parser.on('data', console.log);
 ```
 
 To use the `Delimiter` parser, provide a delimiter as a string, buffer, or array of bytes:
 ```js
-var SerialPort = require('serialport');
-var Delimiter = SerialPort.parsers.Delimiter;
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(new Delimiter({delimiter: Buffer.from('EOL')}));
+const SerialPort = require('serialport');
+const Delimiter = SerialPort.parsers.Delimiter;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(new Delimiter({ delimiter: Buffer.from('EOL') }));
 parser.on('data', console.log);
 ```
 
-To use the `Readline` parser, provide a delimiter (defaults to '\n')
+To use the `Readline` parser, provide a delimiter (defaults to '\n'). Data is emitted as string controllable by the `encoding` option (defaults to `utf8`).
 ```js
-var SerialPort = require('serialport');
-var Readline = SerialPort.parsers.Readline;
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(Readline({delimiter: '\r\n'}));
+const SerialPort = require('serialport');
+const Readline = SerialPort.parsers.Readline;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(Readline({ delimiter: '\r\n' }));
 parser.on('data', console.log);
 ```
 
-To use the `Ready` parser provide a byte start sequence. After the bytes have been received data events will be passed through.
+To use the `Ready` parser provide a byte start sequence. After the bytes have been received data events are passed through.
 ```js
-var SerialPort = require('serialport');
-var Ready = SerialPort.parsers.Ready;
-var port = new SerialPort('/dev/tty-usbserial1');
-var parser = port.pipe(Ready({data: 'READY'}));
+const SerialPort = require('serialport');
+const Ready = SerialPort.parsers.Ready;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(Ready({ data: 'READY' }));
+parser.on('ready', () => console.log('the ready byte sequence has been received'))
 parser.on('data', console.log); // all data after READY is received
+```
+
+To use the `Regex` parser provide a regular expression to split the incoming text upon. Data is emitted as string controllable by the `encoding` option (defaults to `utf8`).
+```js
+const SerialPort = require('serialport');
+const Regex = SerialPort.parsers.Regex;
+const port = new SerialPort('/dev/tty-usbserial1');
+const parser = port.pipe(Regex({ regex: /[\r\n]+/ }));
+parser.on('data', console.log);
 ```
  */
 
 module.exports = {
-  Readline: require('./readline'),
-  Delimiter: require('./delimiter'),
   ByteLength: require('./byte-length'),
-  Regex: require('./regex'),
-  Ready: require('./ready')
+  Delimiter: require('./delimiter'),
+  Readline: require('./readline'),
+  Ready: require('./ready'),
+  Regex: require('./regex')
 };

--- a/lib/parsers/readline.js
+++ b/lib/parsers/readline.js
@@ -1,26 +1,18 @@
 'use strict';
-
-const inherits = require('util').inherits;
 const Buffer = require('safe-buffer').Buffer;
 const DelimiterParser = require('./delimiter');
 
-function ReadlineParser(options) {
-  if (!(this instanceof ReadlineParser)) {
-    return new ReadlineParser(options);
+module.exports = class ReadLineParser extends DelimiterParser {
+  constructor(options) {
+    const opts = Object.assign({
+      delimiter: Buffer.from('\n', 'utf8'),
+      encoding: 'utf8'
+    }, options);
+
+    if (typeof opts.delimiter === 'string') {
+      opts.delimiter = Buffer.from(opts.delimiter, opts.encoding);
+    }
+
+    super(opts);
   }
-
-  options = options || {};
-
-  if (options.delimiter === undefined) {
-    options.delimiter = Buffer.from('\n', 'utf8');
-  }
-
-  DelimiterParser.call(this, options);
-
-  const encoding = options.encoding || 'utf8';
-  this.delimiter = Buffer.from(options.delimiter, encoding);
-  this.setEncoding(encoding);
-}
-
-inherits(ReadlineParser, DelimiterParser);
-module.exports = ReadlineParser;
+};

--- a/lib/parsers/ready.js
+++ b/lib/parsers/ready.js
@@ -1,55 +1,47 @@
 'use strict';
 const Buffer = require('safe-buffer').Buffer;
-const inherits = require('util').inherits;
 const Transform = require('stream').Transform;
 
-function ReadyParser(options) {
-  if (!(this instanceof ReadyParser)) {
-    return new ReadyParser(options);
-  }
-  Transform.call(this, options);
-
-  options = options || {};
-
-  if (options.delimiter === undefined) {
-    throw new TypeError('"delimiter" is not a bufferable object');
-  }
-
-  if (options.delimiter.length === 0) {
-    throw new TypeError('"delimiter" has a 0 or undefined length');
-  }
-
-  this.delimiter = Buffer.from(options.delimiter);
-  this.readOffset = 0;
-  this.ready = false;
-}
-
-inherits(ReadyParser, Transform);
-
-ReadyParser.prototype._transform = function(chunk, encoding, cb) {
-  if (this.ready) {
-    this.push(chunk);
-    return cb();
-  }
-  const delimiter = this.delimiter;
-  let chunkOffset = 0;
-  while (this.readOffset < delimiter.length && chunkOffset < chunk.length) {
-    if (delimiter[this.readOffset] === chunk[chunkOffset]) {
-      this.readOffset++;
-    } else {
-      this.readOffset = 0;
+module.exports = class ReadyParser extends Transform {
+  constructor(options) {
+    options = options || {};
+    if (options.delimiter === undefined) {
+      throw new TypeError('"delimiter" is not a bufferable object');
     }
-    chunkOffset++;
-  }
-  if (this.readOffset === delimiter.length) {
-    this.ready = true;
-    this.emit('ready');
-    const chunkRest = chunk.slice(chunkOffset);
-    if (chunkRest.length > 0) {
-      this.push(chunkRest);
+
+    if (options.delimiter.length === 0) {
+      throw new TypeError('"delimiter" has a 0 or undefined length');
     }
+
+    super(options);
+    this.delimiter = Buffer.from(options.delimiter);
+    this.readOffset = 0;
+    this.ready = false;
   }
-  cb();
+
+  _transform(chunk, encoding, cb) {
+    if (this.ready) {
+      this.push(chunk);
+      return cb();
+    }
+    const delimiter = this.delimiter;
+    let chunkOffset = 0;
+    while (this.readOffset < delimiter.length && chunkOffset < chunk.length) {
+      if (delimiter[this.readOffset] === chunk[chunkOffset]) {
+        this.readOffset++;
+      } else {
+        this.readOffset = 0;
+      }
+      chunkOffset++;
+    }
+    if (this.readOffset === delimiter.length) {
+      this.ready = true;
+      this.emit('ready');
+      const chunkRest = chunk.slice(chunkOffset);
+      if (chunkRest.length > 0) {
+        this.push(chunkRest);
+      }
+    }
+    cb();
+  }
 };
-
-module.exports = ReadyParser;

--- a/lib/parsers/regex.js
+++ b/lib/parsers/regex.js
@@ -1,57 +1,40 @@
 'use strict';
-
-const Buffer = require('safe-buffer').Buffer;
-const inherits = require('util').inherits;
 const Transform = require('stream').Transform;
 
-function RegexParser(options) {
-  if (!(this instanceof RegexParser)) {
-    return new RegexParser(options);
+module.exports = class RegexParser extends Transform {
+  constructor(options) {
+    const opts = Object.assign({
+      encoding: 'utf8'
+    }, options);
+
+    if (opts.regex === undefined) {
+      throw new TypeError('"options.regex" must be a regular expression pattern or object');
+    }
+
+    if (!(opts.regex instanceof RegExp)) {
+      opts.regex = new RegExp(opts.regex);
+    }
+    super(opts);
+
+    this.regex = opts.regex;
+    this.buffer = '';
   }
-  Transform.call(this, options);
 
-  options = options || {};
+  _transform(chunk, encoding, cb) {
+    const data = this.buffer + chunk;
+    const parts = data.split(this.regex);
+    this.buffer = parts.pop();
+    console.log('buffer', this.buffer, 'parts', parts);
 
-  if (options.delimiter === undefined) {
-    throw new TypeError('"delimiter" is not a RegExp object or a string');
+    parts.forEach((part) => {
+      this.push(part);
+    });
+    cb();
   }
 
-  if (options.delimiter.length === 0) {
-    throw new TypeError('"delimiter" has a 0 or undefined length');
+  _flush(cb) {
+    this.push(this.buffer);
+    this.buffer = '';
+    cb();
   }
-
-  if (!(options.delimiter instanceof RegExp)) {
-    options.delimiter = new RegExp(options.delimiter);
-  }
-
-  const encoding = options.encoding || 'utf8';
-  this.setEncoding(encoding);
-
-  this.delimiter = options.delimiter;
-  this.buffer = Buffer.alloc(0);
-}
-
-inherits(RegexParser, Transform);
-
-RegexParser.prototype._transform = function(chunk, encoding, cb) {
-  let data = Buffer.concat([this.buffer, chunk]).toString();
-
-  const parts = data.split(this.delimiter);
-
-  data = parts.pop();
-
-  parts.forEach((part) => {
-    this.push(part);
-  });
-
-  this.buffer = Buffer.from(data);
-  cb();
 };
-
-RegexParser.prototype._flush = function(cb) {
-  this.push(this.buffer);
-  this.buffer = Buffer.alloc(0);
-  cb();
-};
-
-module.exports = RegexParser;

--- a/test/parser-byte-length.js
+++ b/test/parser-byte-length.js
@@ -6,12 +6,6 @@ const sinon = require('sinon');
 const ByteLengthParser = require('../lib/parsers/byte-length');
 
 describe('ByteLengthParser', () => {
-  it('works without new', () => {
-    // eslint-disable-next-line new-cap
-    const parser = ByteLengthParser({ length: 4 });
-    assert.instanceOf(parser, ByteLengthParser);
-  });
-
   it('emits data events every 8 bytes', () => {
     const data = Buffer.from('Robots are so freaking cool!');
     const spy = sinon.spy();

--- a/test/parser-delimiter.js
+++ b/test/parser-delimiter.js
@@ -7,12 +7,6 @@ const sinon = require('sinon');
 const DelimiterParser = require('../lib/parsers/delimiter');
 
 describe('DelimiterParser', () => {
-  it('works without new', () => {
-    // eslint-disable-next-line new-cap
-    const parser = DelimiterParser({ delimiter: Buffer.from([0]) });
-    assert.instanceOf(parser, DelimiterParser);
-  });
-
   it('transforms data to strings split on a delimiter', () => {
     const spy = sinon.spy();
     const parser = new DelimiterParser({
@@ -29,7 +23,7 @@ describe('DelimiterParser', () => {
   });
 
   it('flushes remaining data when the stream ends', () => {
-    const parser = DelimiterParser({ delimiter: Buffer.from([0]) });
+    const parser = new DelimiterParser({ delimiter: Buffer.from([0]) });
     const spy = sinon.spy();
     parser.on('data', spy);
     parser.write(Buffer.from([1]));

--- a/test/parser-readline.js
+++ b/test/parser-readline.js
@@ -7,12 +7,6 @@ const sinon = require('sinon');
 const ReadlineParser = require('../lib/parsers/readline');
 
 describe('ReadlineParser', () => {
-  it('works without new', () => {
-    // eslint-disable-next-line new-cap
-    const parser = ReadlineParser();
-    assert.instanceOf(parser, ReadlineParser);
-  });
-
   it('transforms data to strings split on a delimiter', () => {
     const spy = sinon.spy();
     const parser = new ReadlineParser();

--- a/test/parser-ready.js
+++ b/test/parser-ready.js
@@ -7,12 +7,6 @@ const sinon = require('sinon');
 const ReadyParser = require('../lib/parsers/ready');
 
 describe('ReadyParser', () => {
-  it('works without new', () => {
-    // eslint-disable-next-line new-cap
-    const parser = ReadyParser({ delimiter: Buffer.from([0]) });
-    assert.instanceOf(parser, ReadyParser);
-  });
-
   it('emits data received after the ready data', () => {
     const spy = sinon.spy();
     const parser = new ReadyParser({

--- a/test/parser-regex.js
+++ b/test/parser-regex.js
@@ -7,29 +7,25 @@ const sinon = require('sinon');
 const RegexParser = require('../lib/parsers/regex');
 
 describe('RegexParser', () => {
-  it('works without new', () => {
-    // eslint-disable-next-line new-cap
-    const parser = RegexParser({ delimiter: Buffer.from([0]) });
-    assert.instanceOf(parser, RegexParser);
-  });
-
   it('transforms data to strings split on either carriage return or new line', () => {
     const spy = sinon.spy();
     const parser = new RegexParser({
-      delimiter: new RegExp(/\r\n|\n\r|\n|\r/)
+      regex: /[\r\n]+/
     });
     parser.on('data', spy);
-    parser.write(Buffer.from('I love robots\n\rEach '));
+    parser.write(Buffer.from('I love robots\r\nEach '));
     parser.write(Buffer.from('and Every One\r'));
     parser.write(Buffer.from('even you!'));
+    parser.write(Buffer.from('\nThe angry red robot'));
 
+    assert(spy.calledThrice, 'expecting 3 data events');
     assert.deepEqual(spy.getCall(0).args[0], 'I love robots');
     assert.deepEqual(spy.getCall(1).args[0], 'Each and Every One');
-    assert(spy.calledTwice);
+    assert.deepEqual(spy.getCall(2).args[0], 'even you!');
   });
 
   it('flushes remaining data when the stream ends', () => {
-    const parser = RegexParser({ delimiter: /\n/ });
+    const parser = new RegexParser({ regex: /\n/ });
     const spy = sinon.spy();
     parser.on('data', spy);
     parser.write(Buffer.from([1]));
@@ -39,43 +35,31 @@ describe('RegexParser', () => {
     assert.deepEqual(spy.getCall(0).args[0], Buffer.from([1]).toString());
   });
 
-  it('throws when not provided with a delimiter', () => {
+  it('throws when not provided with a regex', () => {
     assert.throws(() => {
       new RegexParser({});
     });
   });
 
-  it('throws when called with a 0 length delimiter', () => {
+  it('throws when called with an invalid regex expression', () => {
     assert.throws(() => {
       new RegexParser({
-        delimiter: Buffer.alloc(0)
-      });
-    });
-
-    assert.throws(() => {
-      new RegexParser({
-        delimiter: ''
-      });
-    });
-
-    assert.throws(() => {
-      new RegexParser({
-        delimiter: []
+        regex: '\\'
       });
     });
   });
 
-  it('allows setting of the delimiter with a regex string', () => {
+  it('allows setting of the regex with a regex string', () => {
     const spy = sinon.spy();
-    const parser = new RegexParser({ delimiter: 'a|b' });
+    const parser = new RegexParser({ regex: 'a|b' });
     parser.on('data', spy);
     parser.write('bhow are youa');
     assert(spy.calledWith('how '));
     assert(spy.calledWith('re you'));
   });
 
-  it('allows setting of the delimiter with a buffer', () => {
-    const parser = new RegexParser({ delimiter: Buffer.from('a|b') });
+  it('allows setting of the regex with a buffer', () => {
+    const parser = new RegexParser({ regex: Buffer.from('a|b') });
     const spy = sinon.spy();
     parser.on('data', spy);
     parser.write('bhow are youa');
@@ -86,7 +70,7 @@ describe('RegexParser', () => {
   it('allows setting of encoding', () => {
     const spy = sinon.spy();
     const parser = new RegexParser({
-      delimiter: /\r/,
+      regex: /\r/,
       encoding: 'hex'
     });
     parser.on('data', spy);
@@ -95,9 +79,9 @@ describe('RegexParser', () => {
     assert.equal(spy.getCall(1).args[0], '62');
   });
 
-  it('Works when buffer starts with regex delimiter', () => {
+  it('Works when buffer starts with regex regex', () => {
     const data = Buffer.from('\rHello\rWorld\r');
-    const parser = new RegexParser({ delimiter: /\r/ });
+    const parser = new RegexParser({ regex: /\r/ });
     const spy = sinon.spy();
     parser.on('data', spy);
     parser.write(data);
@@ -106,15 +90,15 @@ describe('RegexParser', () => {
 
   it('should match unicode in buffer string', () => {
     const data = Buffer.from('\u000aHello\u000aWorld\u000d\u000a!');
-    const parser = new RegexParser({ delimiter: /\r\n|\n/ });
+    const parser = new RegexParser({ regex: /\r\n|\n/ });
     const spy = sinon.spy();
     parser.on('data', spy);
     parser.write(data);
     assert.equal(spy.callCount, 2);
   });
 
-  it('continues looking for delimiters in the next buffers', () => {
-    const parser = new RegexParser({ delimiter: /\r\n|\n/ });
+  it('continues looking for regexs in the next buffers', () => {
+    const parser = new RegexParser({ regex: /\r\n|\n/ });
     const spy = sinon.spy();
     parser.on('data', spy);
     parser.write(Buffer.from('This could be\na poem '));
@@ -127,7 +111,7 @@ describe('RegexParser', () => {
 
   it('doesn\'t emits empty data events', () => {
     const spy = sinon.spy();
-    const parser = new RegexParser({ delimiter: /a|b/ });
+    const parser = new RegexParser({ regex: /a|b/ });
     parser.on('data', spy);
     parser.write(Buffer.from('abaFab'));
     assert(spy.calledOnce);


### PR DESCRIPTION
- Reduces code a bit
- Provides a better code example
- clean up options passed into transform streams

On @frank-dspeed's prompting.