### PR TITLE
Lets try prebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # MAKE SURE ALL ADDITIONS HERE ARE MIRRORED INTO THE .npmignore AS WELL
+.mailmap
 build/
+coverage
 node_modules
 npm-debug.log
-coverage
-.mailmap
 package-lock.json
+Release/
+prebuilds/

--- a/.npmignore
+++ b/.npmignore
@@ -20,9 +20,10 @@ changelog.md
 .DS_Store
 
 # MIRRORED FROM .gitignore PLEASE MAINTAIN
+.mailmap
 build/
+coverage
 node_modules
 npm-debug.log
-coverage
-.mailmap
 package-lock.json
+Release/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,6 @@ addons:
     - g++-4.8
     - g++-4.8-multilib
     - gcc-multilib
-    - libgtk2.0-0
-    - libxtst6
-    - libnotify4
-    - libgconf2-4
-    - libgtk2.0-0:i386
-    - libxtst6:i386
-    - libnotify4:i386
-    - libgconf2-4:i386
-    - libnss3:i386
-    - libasound2:i386
-    - libxss1:i386
-    - socat
 
 # Build matrix
 os:
@@ -29,16 +17,14 @@ os:
 - osx
 env:
   global:
-  - secure: "qEdwCY/ilHkqWkqasN5MgWCnzzop4lEYkbpxEiVMTZBY12p4uV6ysPQ+ZLZcx10Cg90RIQlsPeEANIhCzkWfnQi+ySmeiKY9JR2eSnb69wM7dBQ/uxv04eVChAlZSsDHwmTIIzIzZFsrWrcwwJaENGCJYKqZ9LKOiGFGQ8Is09A="
+  - secure: "L+AGMJc5NAsuym+xzB4FWj0c2rCobosixkoxLBhDBVkLiYsMtfS9y1w8Xz0pbWKJnJAH9tfwHluu5aX2qYk2HbreSyNzy8hbPW+9RbSyAQexeiZG4mLuDEz0xvlpCCQBsS1OfMypQk0/JvL4oA9B/xasrpkeVuPI7dwAz2WcFms="
   matrix:
   - TRAVIS_NODE_VERSION="4"
   - TRAVIS_NODE_VERSION="4" ARCH="x86"
   - TRAVIS_NODE_VERSION="6"
   - TRAVIS_NODE_VERSION="6" ARCH="x86"
-  - TRAVIS_NODE_VERSION="8"
-  - TRAVIS_NODE_VERSION="8" ARCH="x86"
-  - TRAVIS_ELECTRON_VERSION="1.4.12" TRAVIS_NODE_VERSION="6"
-  - TRAVIS_ELECTRON_VERSION="1.4.12" ARCH="x86" TRAVIS_NODE_VERSION="6"
+  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8"
+  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
 matrix:
   exclude:
   - os: osx
@@ -46,48 +32,47 @@ matrix:
   - os: osx
     env: TRAVIS_NODE_VERSION="6" ARCH="x86"
   - os: osx
-    env: TRAVIS_NODE_VERSION="8" ARCH="x86"
-  - os: osx
-    env: TRAVIS_ELECTRON_VERSION="1.4.12" ARCH="x86" TRAVIS_NODE_VERSION="6"
-  - os: linux
-    env: TRAVIS_ELECTRON_VERSION="1.4.12" ARCH="x86" TRAVIS_NODE_VERSION="6"
+    env: BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
 
 before_install:
-# reinstall latest nvm
-- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh
-- nvm install $TRAVIS_NODE_VERSION
-- PATH=$PATH:`pwd`/node_modules/.bin
 
-- BASE_URL=$(node -p "'https://nodejs.org/dist/' + process.version")
-- X86_FILE=$(node -p "'node-' + process.version + '-' + process.platform + '-x86'")
 # download node if testing x86 architecture
-- if [[ "$ARCH" == "x86" ]]; then wget $BASE_URL/$X86_FILE.tar.gz; tar -xf $X86_FILE.tar.gz; export PATH=$X86_FILE/bin:$PATH; fi
-
-# upgrade npm if on node 4 as it doesn't like our dev peer deps
-- if [[ $TRAVIS_NODE_VERSION == "4" ]]; then npm install -g npm; fi
-
-# print versions
-- uname -a
-- file `which node`
-- node --version
-- node -p 'process.platform + "@" + process.arch'
-- npm --version
+- >
+  if [[ "$ARCH" == "x86" ]]; then
+    BASE_URL=$(node -p "'https://nodejs.org/dist/' + process.version");
+    X86_FILE=$(node -p "'node-' + process.version + '-' + process.platform + '-x86'");
+    wget $BASE_URL/$X86_FILE.tar.gz;
+    tar -xf $X86_FILE.tar.gz;
+    nvm deactivate;
+    export PATH=$X86_FILE/bin:$PATH;
+  else
+    nvm install $TRAVIS_NODE_VERSION
+  fi;
 
 # use g++-4.8 on Linux
 - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
 - $CXX --version
 
-# figure out if we should publish
-- PUBLISH_BINARY=false
-# if we are building a tag then publish
-- echo $TRAVIS_BRANCH
-- echo `git describe --tags --always HEAD`
-- if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;
-- echo "Publishing native platform Binary Package? ->" $PUBLISH_BINARY
+# upgrade npm if on node 4 as npm2 doesn't like our dev peer deps
+- if [[ $TRAVIS_NODE_VERSION == "4" ]]; then npm install -g npm; fi
 
 # Cleanup the output of npm
 - npm config set progress false
 - npm config set spin false
+
+# print versions
+- uname -a
+- which node; file `which node`
+- node --version
+- node -p 'process.platform + "@" + process.arch'
+- npm --version
+
+# figure out if we should publish
+- PUBLISH_BINARY=false
+- echo $TRAVIS_BRANCH
+- echo `git describe --tags --always HEAD`
+- if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=$BINARY_BUILDER; fi;
+- echo "Publishing native platform Binary Package? ->" $PUBLISH_BINARY
 
 # setup virtual serialports
 # - >
@@ -95,54 +80,26 @@ before_install:
   # ./bin/echo.js --port ttyV0 &
   # export TEST_PORT=ttyV1
 
-- >
-  if [[ ! -z $TRAVIS_ELECTRON_VERSION ]]; then
-    if [[ $TRAVIS_OS_NAME == "linux" ]]; then
-      export DISPLAY=:99.0
-      sh -e /etc/init.d/xvfb start
-    fi
-
-    export npm_config_target=$TRAVIS_ELECTRON_VERSION
-    export npm_config_arch=$ARCH
-    export npm_config_disturl=https://atom.io/download/atom-shell
-    export npm_config_runtime=electron
-
-    npm install --arch=$ARCH electron@$TRAVIS_ELECTRON_VERSION
-    npm install electron-mocha
-
-    echo "installed Electron $TRAVIS_ELECTRON_VERSION"
-  fi
-
 install:
 # ensure source install works
 - npm install --build-from-source
-
 
 script:
   # linting no longer works on node 4
 - >
   if [[ $TRAVIS_NODE_VERSION != "4" ]]; then
     npm run lint
-  fi
+  fi;
 
 - npm run docs:diff
-- >
-  if [[ -z $TRAVIS_ELECTRON_VERSION ]]; then
-    node ./
-    npm test
-  else
-    electron test/electron
-  fi
+- node ./
+- npm test
 
 # if publishing, do it
-- if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp package; fi;
-- if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp-github publish --release; fi;
-
-# cleanup
-- node-pre-gyp clean
-
-# test binary exists
-- if [[ $PUBLISH_BINARY == true ]]; then npm install --fallback-to-build=false; fi;
+- >
+  if [[ $PUBLISH_BINARY == true ]]; then
+    npm run prebuild-upload;
+  fi;
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -13,7 +13,7 @@ This can be checked in the .travis.yml file and appveyor.yml file. Within these 
 2. Fill out `changelog.md`
 3. Bump up npm version in `package.json`
 4. Update the `.docs/README.hbs` to reference this current version and to previous major version docs then regenerate docs `npm run docs`.
-5. Commit then generate new tags based on package.json version number with `git tag 5.0.0 -a` and include the change log in the tag's annotation.
+5. Commit then generate new tags based on package.json version number with `git tag v5.0.0 -a` and include the change log in the tag's annotation.
 6. Push tags to Github with `git push --tags`
 7. `rm -rf package-lock.json node_modules build && npm install`
 8. Publish to npm after builds finish. Builds can take half an hour and occasionally fail for seemingly no reason. Restart any failures in the travis or appeveyor ui. While you wait, remove the content of the Github release message so the tag's text shows. When the entire matrix succeeds and all binaries exist run `npm publish`.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,15 @@
 os: unstable
 environment:
-  NODE_PRE_GYP_GITHUB_TOKEN:
-    secure: VM4yc2j2L3KS5qWLZLY7WUAXoqdB9YkodmXlHC2I+LSF0Y8a2cZ70M0+2+Fd5GkQ
+  prebuild_upload:
+    secure: a/seaM+nUnQWhWUnbyz8fl9vPwuyqDTrFviptDykYp2c46vdTvlAxU6yqD/PpDiI
   COVERALLS_REPO_TOKEN:
     secure: iDcAJCYgJK4tffyzEHbMVR8DatJcIN8eY0h29p9JQkl43TcEcm6Z6JLOBpGDk1MJ
 
   matrix:
   - nodejs_version: "4"
   - nodejs_version: "6"
-  - nodejs_version: "8"
-  - electron_version: "1.4.12"
-    nodejs_version: "6"
+  - binary_builder: "true"
+    nodejs_version: "8"
 
 platform:
 - x86
@@ -25,13 +24,13 @@ matrix:
 
 install:
 - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform;
-- ps: $env:Path += ";$(pwd)\node_modules\.bin";
-# work around bug in npm 2 where id doesn't like our dev dep peers
+# upgrade npm if on node 4 as npm2 doesn't like our dev peer deps
 - ps: >
     if ($env:nodejs_version -eq "4") {
       npm install -g npm | Write-Host;
     }
-    true;
+    npm config set progress false
+    npm config set spin false
 
 - ps: >
     @{
@@ -43,77 +42,42 @@ install:
       "APPVEYOR_REPO_COMMIT_MESSAGE" = $env:APPVEYOR_REPO_COMMIT_MESSAGE
       "git latest tag" = "$(git describe --tags --always HEAD)"
       "appveyor_repo_tag" = $env:appveyor_repo_tag
-      "electron_version" = $env:electron_version
     } | Out-String | Write-Host;
 
 # Check if we're building the latest tag, if so
 # then we publish the binaries if tests pass.
 - ps: >
     if ($env:appveyor_repo_tag -match "true" -and ("$(git describe --tags --always HEAD)" -eq $env:appveyor_repo_tag_name)) {
-      $env:publish_binary = 1;
-    } else {
-      $env:publish_binary = 0;
+      $env:publish_binary = $env:binary_builder;
     }
-    true;
-
-- ps: >
-    if ($env:publish_binary -eq 1) {
+    if ($env:publish_binary -eq "true") {
       "We're publishing a binary!" | Write-Host
     } else {
       "We're not publishing a binary" | Write-Host
     }
     true;
 
-# Cleanup the output of npm
-- ps: >
-    npm config set progress false
-    npm config set spin false
-
 # We don't currently have a port to test on windows
 # - ps: $env:TEST_PORT = "COM1";
 
-# Setup Electron variables
-- ps: >
-    if ($env:electron_version) {
-      "We're an electron build, setup variables" | Write-Host
-      $env:npm_config_target = $env:electron_version
-      $env:npm_config_disturl = "https://atom.io/download/atom-shell"
-      $env:npm_config_runtime = "electron"
-
-      if ($env:plaftorm -eq "x86") {
-        $env:npm_config_arch = "ia32"
-      } else {
-        $env:npm_config_arch = "x64"
-      }
-
-      "Install electron and electron-mocha" | Write-Host
-
-      npm install -g electron@$env:electron_version
-      npm install electron-mocha
-    }
-    true;
-
 build_script:
-- npm install --build-from-source --msvs_version=2013
+- npm install --build-from-source
 
 test_script:
 - ps: >
     if ($env:nodejs_version -ne "4") {
       npm run lint
     }
+    node ./
+
+# If we run npm test in powershell it'll have the wrong encoding so we have to do it like this
+- npm test
+
+- ps: >
+    if ($env:publish_binary -eq "true") {
+      npm run prebuild-upload
+    }
     true;
-
-# If we run npm test in powershell it'll have the wrong encoding
-# so we have to do it like this
-
-- IF DEFINED electron_version (electron test/electron)
-- IF NOT DEFINED electron_version (node ./)
-- IF NOT DEFINED electron_version (npm test)
-
-- IF %PUBLISH_BINARY% == 1 (node-pre-gyp package 2>&1)
-- IF %PUBLISH_BINARY% == 1 (node-pre-gyp-github publish --release 2>&1)
-- IF %PUBLISH_BINARY% == 1 (node-pre-gyp clean)
-- IF %PUBLISH_BINARY% == 1 (npm install --fallback-to-build=false)
 
 after_test:
 - pip install codecov && codecov --file coverage\coverage.json

--- a/package.json
+++ b/package.json
@@ -1,16 +1,11 @@
 {
   "name": "serialport",
-  "version": "5.0.0",
+  "version": "5.1.0-beta5",
   "description": "Node.js package to access serial ports. Linux, OSX and Windows. Welcome your robotic JavaScript overlords. Better yet, program them!",
   "author": {
     "name": "Chris Williams",
     "email": "voodootikigod@gmail.com",
     "url": "http://www.voodootikigod.com"
-  },
-  "binary": {
-    "module_name": "serialport",
-    "module_path": "build/{configuration}/",
-    "host": "https://github.com/EmergingTechnologyAdvisors/node-serialport/releases/download/5.0.0"
   },
   "main": "lib",
   "repository": {
@@ -67,7 +62,8 @@
     "commander": "^2.11.0",
     "debug": "^2.6.6",
     "nan": "^2.6.2",
-    "node-pre-gyp": "^0.6.36",
+    "prebuild": "^6.2.1",
+    "prebuild-install": "^2.2.1",
     "promirepl": "^1.0.1",
     "safe-buffer": "^5.0.1"
   },
@@ -84,13 +80,9 @@
     "istanbul": "^0.4.4",
     "jsdoc-to-markdown": "^3.0.0",
     "mocha": "^3.4.2",
-    "node-pre-gyp-github": "^1.1.2",
     "proxyquire": "^1.7.10",
     "sinon": "^2.3.8"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "engines": {
     "node": ">=4.0.0"
   },
@@ -104,7 +96,6 @@
     "arduino-test": "TEST_PORT=$(./bin/find-arduino.js) npm test",
     "docs": "jsdoc2md --no-cache -t .docs/README.hbs --partial .docs/sig-name.hbs --partial .docs/sig-link.hbs --partial .docs/edit-warning.hbs -r table --separators --name-format -f lib/* lib/bindings/* lib/parsers/* > README.md",
     "docs:diff": "jsdoc2md --no-cache -t .docs/README.hbs --partial .docs/sig-name.hbs --partial .docs/sig-link.hbs --partial .docs/edit-warning.hbs -r table --separators --name-format -f lib/* lib/bindings/* lib/parsers/* | diff README.md - || (echo 'Docs out of date, run `npm run docs` and commit the new README.md' && false)",
-    "install": "node-pre-gyp install --fallback-to-build",
     "lint": "eslint lib test bin examples",
     "rebuild-all": "npm rebuild && node-gyp rebuild",
     "repl": "node bin/repl.js",
@@ -112,7 +103,11 @@
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha",
     "test:watch": "mocha -w",
     "valgrind": "TEST_PORT=$(./bin/find-arduino.js) valgrind --leak-check=full node test/manual-testing/memory-binding.js",
-    "debugger": "TEST_PORT=$(./bin/find-arduino.js) node --inspect --debug-brk test/manual-testing/performance.js"
+    "debugger": "TEST_PORT=$(./bin/find-arduino.js) node --inspect --debug-brk test/manual-testing/performance.js",
+    "install": "prebuild-install || node-gyp rebuild",
+    "rebuild": "prebuild --compile",
+    "prebuild": "prebuild --all --strip --verbose",
+    "prebuild-upload": "prebuild --all --strip --verbose"
   },
   "gypfile": true
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "commander": "^2.11.0",
     "debug": "^2.6.6",
     "nan": "^2.6.2",
-    "prebuild": "^6.2.1",
     "prebuild-install": "^2.2.1",
     "promirepl": "^1.0.1",
     "safe-buffer": "^5.0.1"
@@ -80,6 +79,7 @@
     "istanbul": "^0.4.4",
     "jsdoc-to-markdown": "^3.0.0",
     "mocha": "^3.4.2",
+    "prebuild": "^6.2.1",
     "proxyquire": "^1.7.10",
     "sinon": "^2.3.8"
   },


### PR DESCRIPTION
I released this branch as `serialport@5.1.0-beta5` if you're using electron give it a try!

- Build once on each platform (win32, win64, linux32, linux64, osx)
- upload to github
- Binaries for windows are megabytes smaller!
- Now 60 binaries per release!?!?!?!?
- Builds are much easier to manage
- Removes the bundled node-pre-gyp which was big `npm i --production` went from 11mb to 4.9Mb. `prebuild-install` is still larger than all our binaries but smaller none the less.