### PR TITLE
Asynchronous callbacks for reading and writing on Windows, attempt 2.

### DIFF
--- a/src/serialport_win.h
+++ b/src/serialport_win.h
@@ -15,6 +15,8 @@ struct WriteBaton {
   size_t bufferLength;
   size_t offset;
   size_t bytesWritten;
+  void* hThread;
+  bool complete;
   Nan::Persistent<v8::Object> buffer;
   Nan::Callback callback;
   int result;
@@ -23,7 +25,9 @@ struct WriteBaton {
 
 NAN_METHOD(Write);
 void EIO_Write(uv_work_t* req);
-void EIO_AfterWrite(uv_work_t* req);
+void EIO_AfterWrite(uv_async_t* req);
+DWORD __stdcall WriteThread(LPVOID param);
+
 
 struct ReadBaton {
   int fd;
@@ -32,13 +36,17 @@ struct ReadBaton {
   size_t bytesRead;
   size_t bytesToRead;
   size_t offset;
+  void* hThread;
+  bool complete;
   char errorString[ERROR_STRING_SIZE];
   Nan::Callback callback;
 };
 
 NAN_METHOD(Read);
 void EIO_Read(uv_work_t* req);
-void EIO_AfterRead(uv_work_t* req);
+void EIO_AfterRead(uv_async_t* req);
+DWORD __stdcall ReadThread(LPVOID param);
+
 
 NAN_METHOD(List);
 void EIO_List(uv_work_t* req);


### PR DESCRIPTION
Instead of ReadFile and WriteFile, which block and transfer data synchronously, use ReadFileEx and WriteFileEx, which both allow async callbacks. In addition, change how timeouts are used for ReadFile*, using an unlimited timeout for the first byte, and no timeout for the rest of the data in the input buffer. This removes the need to poll entirely, while still retrieving all data available in the input buffer. In both cases, the I/O operations happen in their own threads, since Windows requires IOCompletion callbacks to wait for their calling thread to be in an "alertable wait state".

Fixes #1221