### PR TITLE
Better error message for incorect parameters under Windows

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -30,6 +30,9 @@ void ErrorCodeToString(const char* prefix, int errorCode, char *errorStr) {
   case ERROR_OPERATION_ABORTED:
     _snprintf_s(errorStr, ERROR_STRING_SIZE, _TRUNCATE, "%s: Operation aborted", prefix);
     break;
+  case ERROR_INVALID_PARAMETER:
+    _snprintf_s(errorStr, ERROR_STRING_SIZE, _TRUNCATE, "%s: The parameter is incorrect", prefix);
+    break;      
   default:
     _snprintf_s(errorStr, ERROR_STRING_SIZE, _TRUNCATE, "%s: Unknown error code %d", prefix, errorCode);
     break;


### PR DESCRIPTION
When opening a serial port with wrong parameters Windows returns:

> Error: Open (SetCommState): Unknown error code 87

which is confusing and not very helpful. See #1353

With this fix users will get more meanigful message.

Error description comes from the Microsoft documentation:

> ERROR_INVALID_PARAMETER
>    87 (0x57)
>    The parameter is incorrect.

https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx